### PR TITLE
Narrow `sector_level` type with Literal and add integration test for NACE selection

### DIFF
--- a/app/api/routes/projector.py
+++ b/app/api/routes/projector.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional, List, Literal
 from fastapi import APIRouter
 from fastapi import Form
 
@@ -49,7 +49,7 @@ async def analyze_skills(
         page_size: int = Form(50),
         demo: bool = Form(False),
         include_sectoral: bool = Form(False),
-        sector_level: str = Form("isco_group"),
+        sector_level: Literal["isco_group", "nace_code", "nace_division", "nace_group", "nace_class"] = Form("isco_group"),
         skill_group_level: int = Form(1),
         occupation_level: int = Form(1),
 ):

--- a/app/services/projector_service.py
+++ b/app/services/projector_service.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional, List, Literal
 
 from fastapi import Form
 
@@ -21,7 +21,7 @@ class ProjectorService:
         page_size: int = Form(50),
         demo: bool = Form(False),
         include_sectoral: bool = Form(False),
-        sector_level: str = Form("isco_group"),
+        sector_level: Literal["isco_group", "nace_code", "nace_division", "nace_group", "nace_class"] = Form("isco_group"),
         skill_group_level: int = Form(1),
         occupation_level: int = Form(1),):
         self.engine.stop_requested = False

--- a/app/test.py
+++ b/app/test.py
@@ -2368,6 +2368,63 @@ def test_endpoint_analyze_skills_sectoral_top_groups_include_group_label():
         assert "group_label" in sector["matrix_groups"]["top_groups"][0]
 
 
+@pytest.mark.integration
+def test_endpoint_analyze_skills_sectoral_supports_nace_hierarchy_selection():
+    form_data = {
+        "keywords": ["developer"],
+        "min_date": "2024-01-01",
+        "max_date": "2024-01-10",
+        "include_sectoral": True,
+        "sector_level": "nace_class",
+        "skill_group_level": 1,
+        "occupation_level": 1,
+    }
+
+    fake_jobs = [
+        {
+            "occupation_id": "occ_1",
+            "skills": ["skill_obs"],
+            "upload_date": "2024-01-02",
+        }
+    ]
+
+    with patch.object(tracker, "fetch_all_jobs", new_callable=AsyncMock) as m_fetch, \
+         patch.object(tracker, "fetch_skill_names", new_callable=AsyncMock) as m_fetch_skills, \
+         patch.object(tracker, "fetch_occupation_labels", new_callable=AsyncMock) as m_fetch_occ:
+
+        m_fetch.return_value = fake_jobs
+        m_fetch_skills.return_value = None
+        m_fetch_occ.return_value = None
+
+        engine.occupation_meta = {
+            "occ_1": {"label": "Software developer", "isco_group": "C2", "nace_code": "C10.11"},
+        }
+        engine.occupation_group_labels = {"C2": "C2"}
+        engine.occ_skill_relations = defaultdict(set)
+        engine.occ_skill_relations["occ_1"] = {"skill_a"}
+        engine.skill_map = {
+            "skill_a": {"label": "Python", "is_green": False, "is_digital": True},
+            "skill_obs": {"label": "Docker", "is_green": False, "is_digital": True},
+        }
+        engine.skill_hierarchy = {
+            "skill_a": {"level_1": "S1", "level_2": "S1.1", "level_3": "S1.1.1"},
+            "skill_obs": {"level_1": "S3", "level_2": "S3.1", "level_3": "S3.1.1"},
+        }
+        engine.esco_matrix_profiles = {
+            ("Matrix 1.1", "http://data.europa.eu/esco/isco/C2"): {
+                "occupation_group_label": "Professionals",
+                "profile": {"S1": 1.0}
+            }
+        }
+
+        response = client.post("/projector/analyze-skills", data=form_data)
+        assert response.status_code == 200
+
+        data = response.json()
+        sector = data["insights"]["sectoral"][0]
+        assert sector["sector"] == "C1011"
+
+
 def test_build_observed_occupation_skill_matrix_accumulates_when_reset_false():
     from app.core.container import ProjectorEngine
 


### PR DESCRIPTION
### Motivation
- Constrain allowed `sector_level` values to a fixed set to catch invalid inputs earlier and make the API contract explicit.

### Description
- Added `Literal` typing and imported it from `typing`, replacing the free-form `sector_level: str` with `sector_level: Literal["isco_group","nace_code","nace_division","nace_group","nace_class"]` in `app/api/routes/projector.py` and `app/services/projector_service.py` to enforce valid taxonomy levels.  
- Added an integration test `test_endpoint_analyze_skills_sectoral_supports_nace_hierarchy_selection` in `app/test.py` to verify the endpoint accepts `sector_level: "nace_class"` and returns the expected sector mapping.

### Testing
- Ran the test suite with `pytest`, including the new integration test `test_endpoint_analyze_skills_sectoral_supports_nace_hierarchy_selection`, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d15362a083218b803515b402b46f)