### PR TITLE
Add `sector_system` option and NACE support to /projector/analyze-skills

### DIFF
--- a/app/api/routes/projector.py
+++ b/app/api/routes/projector.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional, List, Literal
 from fastapi import APIRouter
 from fastapi import Form
 
@@ -49,7 +49,8 @@ async def analyze_skills(
         page_size: int = Form(50),
         demo: bool = Form(False),
         include_sectoral: bool = Form(False),
-        sector_level: str = Form("isco_group"),
+        sector_system: Literal["isco", "nace"] = Form("isco"),
+        sector_level: Literal["isco_group", "nace_code", "nace_division", "nace_group", "nace_class"] = Form("isco_group"),
         skill_group_level: int = Form(1),
         occupation_level: int = Form(1),
 ):
@@ -68,6 +69,8 @@ async def analyze_skills(
            max_date (str, optional): End date (YYYY-MM-DD).
            location_code (str, optional): Geographic filter (ISO/NUTS).
            occupation_ids (List[str], optional): Sector filter (ESCO).
+           sector_system (str, optional): Sector taxonomy system. Supported values:
+               `isco`, `nace`.
            sector_level (str, optional): Sector taxonomy level. Supported values:
                `isco_group`, `nace_code`, `nace_division`, `nace_group`, `nace_class`.
 
@@ -91,6 +94,7 @@ async def analyze_skills(
                                  page_size,
                                  demo,
                                  include_sectoral,
+                                 sector_system,
                                  sector_level,
                                  skill_group_level,
                                  occupation_level)

--- a/app/services/projector_service.py
+++ b/app/services/projector_service.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional, List, Literal
 
 from fastapi import Form
 
@@ -21,7 +21,8 @@ class ProjectorService:
         page_size: int = Form(50),
         demo: bool = Form(False),
         include_sectoral: bool = Form(False),
-        sector_level: str = Form("isco_group"),
+        sector_system: Literal["isco", "nace"] = Form("isco"),
+        sector_level: Literal["isco_group", "nace_code", "nace_division", "nace_group", "nace_class"] = Form("isco_group"),
         skill_group_level: int = Form(1),
         occupation_level: int = Form(1),):
         self.engine.stop_requested = False
@@ -74,16 +75,21 @@ class ProjectorService:
 
         sectoral_data = None
         if include_sectoral:
-            allowed_sector_levels = {
-                "isco_group",
-                "nace_code",
-                "nace_division",
-                "nace_group",
-                "nace_class"
-            }
-            normalized_sector_level = str(sector_level or "isco_group").strip().lower()
-            if normalized_sector_level not in allowed_sector_levels:
+            normalized_system = str(sector_system or "isco").strip().lower()
+            if normalized_system not in {"isco", "nace"}:
+                normalized_system = "isco"
+
+            requested_level = str(sector_level or "").strip().lower()
+            if normalized_system == "isco":
                 normalized_sector_level = "isco_group"
+            else:
+                allowed_nace_levels = {
+                    "nace_code",
+                    "nace_division",
+                    "nace_group",
+                    "nace_class"
+                }
+                normalized_sector_level = requested_level if requested_level in allowed_nace_levels else "nace_code"
 
             sectoral_data = self.sectoral.build_sectoral_intelligence(
                 jobs=raw,

--- a/app/test.py
+++ b/app/test.py
@@ -2368,6 +2368,121 @@ def test_endpoint_analyze_skills_sectoral_top_groups_include_group_label():
         assert "group_label" in sector["matrix_groups"]["top_groups"][0]
 
 
+@pytest.mark.integration
+def test_endpoint_analyze_skills_sectoral_supports_nace_hierarchy_selection():
+    form_data = {
+        "keywords": ["developer"],
+        "min_date": "2024-01-01",
+        "max_date": "2024-01-10",
+        "include_sectoral": True,
+        "sector_system": "nace",
+        "sector_level": "nace_class",
+        "skill_group_level": 1,
+        "occupation_level": 1,
+    }
+
+    fake_jobs = [
+        {
+            "occupation_id": "occ_1",
+            "skills": ["skill_obs"],
+            "upload_date": "2024-01-02",
+        }
+    ]
+
+    with patch.object(tracker, "fetch_all_jobs", new_callable=AsyncMock) as m_fetch, \
+         patch.object(tracker, "fetch_skill_names", new_callable=AsyncMock) as m_fetch_skills, \
+         patch.object(tracker, "fetch_occupation_labels", new_callable=AsyncMock) as m_fetch_occ:
+
+        m_fetch.return_value = fake_jobs
+        m_fetch_skills.return_value = None
+        m_fetch_occ.return_value = None
+
+        engine.occupation_meta = {
+            "occ_1": {"label": "Software developer", "isco_group": "C2", "nace_code": "C10.11"},
+        }
+        engine.occupation_group_labels = {"C2": "C2"}
+        engine.occ_skill_relations = defaultdict(set)
+        engine.occ_skill_relations["occ_1"] = {"skill_a"}
+        engine.skill_map = {
+            "skill_a": {"label": "Python", "is_green": False, "is_digital": True},
+            "skill_obs": {"label": "Docker", "is_green": False, "is_digital": True},
+        }
+        engine.skill_hierarchy = {
+            "skill_a": {"level_1": "S1", "level_2": "S1.1", "level_3": "S1.1.1"},
+            "skill_obs": {"level_1": "S3", "level_2": "S3.1", "level_3": "S3.1.1"},
+        }
+        engine.esco_matrix_profiles = {
+            ("Matrix 1.1", "http://data.europa.eu/esco/isco/C2"): {
+                "occupation_group_label": "Professionals",
+                "profile": {"S1": 1.0}
+            }
+        }
+
+        response = client.post("/projector/analyze-skills", data=form_data)
+        assert response.status_code == 200
+
+        data = response.json()
+        sector = data["insights"]["sectoral"][0]
+        assert sector["sector"] == "C1011"
+
+@pytest.mark.integration
+def test_endpoint_analyze_skills_sectoral_uses_isco_when_sector_system_is_isco():
+    form_data = {
+        "keywords": ["developer"],
+        "min_date": "2024-01-01",
+        "max_date": "2024-01-10",
+        "include_sectoral": True,
+        "sector_system": "isco",
+        "sector_level": "nace_class",
+        "skill_group_level": 1,
+        "occupation_level": 1,
+    }
+
+    fake_jobs = [
+        {
+            "occupation_id": "occ_1",
+            "skills": ["skill_obs"],
+            "upload_date": "2024-01-02",
+        }
+    ]
+
+    with patch.object(tracker, "fetch_all_jobs", new_callable=AsyncMock) as m_fetch, \
+         patch.object(tracker, "fetch_skill_names", new_callable=AsyncMock) as m_fetch_skills, \
+         patch.object(tracker, "fetch_occupation_labels", new_callable=AsyncMock) as m_fetch_occ:
+
+        m_fetch.return_value = fake_jobs
+        m_fetch_skills.return_value = None
+        m_fetch_occ.return_value = None
+
+        engine.occupation_meta = {
+            "occ_1": {"label": "Software developer", "isco_group": "C2", "nace_code": "C10.11"},
+        }
+        engine.occupation_group_labels = {"C2": "C2"}
+        engine.occ_skill_relations = defaultdict(set)
+        engine.occ_skill_relations["occ_1"] = {"skill_a"}
+        engine.skill_map = {
+            "skill_a": {"label": "Python", "is_green": False, "is_digital": True},
+            "skill_obs": {"label": "Docker", "is_green": False, "is_digital": True},
+        }
+        engine.skill_hierarchy = {
+            "skill_a": {"level_1": "S1", "level_2": "S1.1", "level_3": "S1.1.1"},
+            "skill_obs": {"level_1": "S3", "level_2": "S3.1", "level_3": "S3.1.1"},
+        }
+        engine.esco_matrix_profiles = {
+            ("Matrix 1.1", "http://data.europa.eu/esco/isco/C2"): {
+                "occupation_group_label": "Professionals",
+                "profile": {"S1": 1.0}
+            }
+        }
+
+        response = client.post("/projector/analyze-skills", data=form_data)
+        assert response.status_code == 200
+
+        data = response.json()
+        sector = data["insights"]["sectoral"][0]
+        assert sector["sector"] == "C2"
+
+
 def test_build_observed_occupation_skill_matrix_accumulates_when_reset_false():
     from app.core.container import ProjectorEngine
 


### PR DESCRIPTION
### Motivation
- Expose a sector taxonomy selector so the analyzer can produce sectoral intelligence using either ISCO or NACE hierarchies.
- Ensure the service normalizes requested sector levels correctly and defaults to safe values for each taxonomy.

### Description
- Added a new `sector_system` parameter to the `/projector/analyze-skills` route and to `ProjectorService.analyze_skills` with a `Literal` type allowing `"isco"` or `"nace"` and threaded the value through to the service.
- Constrained `sector_level` to a `Literal` and implemented normalization logic in the service that selects an appropriate default `sector_level` per `sector_system` and validates requested NACE levels.
- Adjusted sectoral branch to use `normalized_system` and `normalized_sector_level` when building sectoral intelligence, preserving previous ISCO defaults when `sector_system` is omitted or invalid.
- Added integration tests to `app/test.py` to verify NACE hierarchy selection and ISCO fallback behavior for the sectoral intelligence flow.

### Testing
- Ran the test suite with `pytest`, including new integration tests `test_endpoint_analyze_skills_sectoral_supports_nace_hierarchy_selection` and `test_endpoint_analyze_skills_sectoral_uses_isco_when_sector_system_is_isco`, and they passed.
- Existing unit tests covering sectoral aggregation and matrix construction were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d15362a083218b803515b402b46f)