### PR TITLE
Add CI quality pipeline for main layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,22 @@
 /cache_data/
 /HCV 3.py
 /.env
+/app/.env
 /.venv/
-.idea
+/.idea/
+
+# Python/test artifacts
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/
+.coverage
+coverage.xml
+coverage-report/
+htmlcov/
+test-results.xml
+integration-test-results.xml
+test-report/
+mutants/
+mutation-report/
+quality-dashboard/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,166 @@
+# Contributing
+
+This repository keeps the application source, tests, CI configuration, and quality tooling together. The runtime product for users should be distributed as a release artifact, package, or Docker image; development tooling stays versioned in the source repository so every build can be reproduced.
+
+## Branch And Release Flow
+
+Use short-lived feature branches and open pull requests into `main`.
+
+```text
+feature/* -> pull request -> quality checks -> main -> runtime artifact
+```
+
+`main` is the stable source channel. It may contain test, CI, and quality tooling because those files define how the project is validated. Users who only need to run the API should consume a released artifact or Docker image rather than a stripped-down branch.
+
+Do not mix unrelated infrastructure work into feature pull requests. CI, dashboard, gate, and reporting changes should use their own pull request.
+
+## Local Development
+
+Install runtime dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Install development dependencies when running the quality tooling locally:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+Start the API from the repository root:
+
+```bash
+uvicorn main:app --reload
+```
+
+Start the dashboard:
+
+```bash
+streamlit run demo_dashboard.py
+```
+
+Keep secrets in `.env` files only. `.env` files are ignored and must not be committed.
+
+## Test Suites
+
+The maintained test entrypoint on `main` is:
+
+```bash
+pytest test.py
+```
+
+Jenkins separates the suite into:
+
+- unit/non-integration tests: `pytest test.py -m "not integration"`
+- integration tests: `pytest test.py -m "integration"`
+
+Integration tests require the application or external service endpoints to be reachable. The `integration` marker is registered in `pytest.ini`.
+
+## Quality Gates
+
+Quality thresholds and check policies live in `pyproject.toml`.
+
+- `[tool.quality_gates]` contains numeric thresholds.
+- `[tool.quality_checks]` describes labels, quality mode, Jenkins meaning, and human-readable rules.
+
+Current enforced gates:
+
+- tests must pass;
+- total coverage must meet the configured coverage gate.
+
+Current advisory/report-only checks:
+
+- mutation score is advisory;
+- lint reports are report-only.
+
+The dashboard intentionally separates two concepts:
+
+- `Jenkins Result`: whether the CI stage completed according to its Jenkins contract;
+- `Quality Outcome`: how the generated metric should be interpreted.
+
+For example, mutation testing can have `Jenkins Result = PASS` and `Quality Outcome = BELOW` because the mutation score is advisory while the stage successfully generated reports.
+
+## Jenkins Pipeline
+
+The Jenkins pipeline is defined in `Jenkinsfile` and runs inside the CI Docker image built from `Dockerfile.ci`.
+
+Main stages:
+
+- `Build CI Image`: builds the isolated Python CI environment.
+- `Prepare Workspace`: removes generated reports and caches.
+- `Run Tests`: runs non-integration tests with coverage and the enforced coverage gate.
+- `Integration Tests`: runs tests marked `integration`.
+- `Code Quality`: generates lint reports without blocking the pipeline.
+- `Mutation Testing`: runs mutmut and generates mutation reports; mutation is advisory.
+
+The pipeline publishes JUnit results, archives generated reports, generates the quality dashboard, and publishes compact GitHub commit statuses.
+
+## GitHub Checks
+
+Jenkins publishes custom GitHub commit statuses:
+
+- `Jenkins / Tests`
+- `Jenkins / Coverage Gate`
+- `Jenkins / Mutation Advisory`
+- `Jenkins / Code Quality`
+
+These statuses are readable summaries with direct `Details` links to the relevant report.
+
+The Jenkins native status, such as `continuous-integration/jenkins/pr-head` or `continuous-integration/jenkins/pr-merge`, represents the full pipeline result. If Jenkins is configured with pull request strategy `Both the current pull request revision and the pull request merged with the current target branch revision`, the `pr-merge` build is the strongest pre-merge signal. It only exists when the pull request can be cleanly merged with the target branch.
+
+Recommended required checks for pull requests:
+
+- the Jenkins native `pr-merge` check when available;
+- CodeQL, if enabled as a repository rule.
+
+The custom Jenkins statuses can remain informational because the native Jenkins status already reflects the enforced stages. They are useful for diagnosis and links.
+
+## Dashboards And Reports
+
+Generated reports are archived by Jenkins and ignored by Git.
+
+Main generated artifacts:
+
+- `quality-dashboard/index.html`: single overview for tests, coverage, mutation, quality gates, and Jenkins context.
+- `test-report/index.html`: readable test report parsed from JUnit XML.
+- `coverage-report/index.html`: coverage HTML report.
+- `mutation-report/index.html`: mutation testing report.
+- `mutation-report/status-survived.html`: survived mutants.
+- `pylint-report.txt` and `flake8-report.json`: lint outputs.
+
+The generated directories and XML files must not be committed.
+
+## Mutation Testing
+
+Mutmut configuration lives in `[tool.mutmut]` in `pyproject.toml`.
+
+On `main`, mutation testing targets the current root-layout modules:
+
+- `main.py`
+- `schemas.py`
+
+Mutation testing is advisory, so a score below the advisory target should be treated as improvement work, not as a broken pipeline.
+
+When the package layout branch is merged, update the mutmut and coverage configuration to the package paths used by that branch.
+
+## Where Things Live
+
+```text
+Jenkinsfile                     CI pipeline
+Dockerfile.ci                   CI image
+pytest.ini                      pytest markers and pytest defaults
+pyproject.toml                  coverage, mutmut, quality gates, quality check policies
+requirements-dev.txt            development and CI dependencies
+tools/quality_gates.py          reads gate thresholds and check policies
+tools/quality_dashboard.py      generates the quality dashboard
+tools/test_report.py            generates the readable test report
+tools/mutation_report.py        generates mutation HTML reports
+tools/github_statuses.py        publishes GitHub commit statuses
+```
+
+## Before Opening A Pull Request
+
+Make sure the pull request is focused on one topic. Avoid mixing feature code with CI or quality infrastructure unless the feature requires the infrastructure change.
+
+At minimum, run the relevant tests locally when practical. The authoritative result is the Jenkins pipeline attached to the pull request.

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -13,9 +13,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt /tmp/requirements.txt
+COPY requirements.txt requirements-dev.txt /tmp/
 RUN python -m pip install --upgrade pip setuptools wheel && \
-    pip install -r /tmp/requirements.txt && \
+    pip install -r /tmp/requirements-dev.txt && \
     pip install pytest pytest-cov flake8 pylint
 
 WORKDIR /workspace

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,7 @@ pipeline {
 
     environment {
         CI_IMAGE = "projector-ci:${env.BUILD_NUMBER}"
+        GITHUB_STATUS_CREDENTIALS_ID = "1efb02bc-566c-433b-9e76-577fcb07cf5b"
     }
 
     stages {
@@ -47,7 +48,11 @@ pipeline {
                         ${CI_IMAGE} \
                         sh -c "
                             rm -rf \
+                                test-report \
                                 coverage-report \
+                                mutation-report \
+                                quality-dashboard \
+                                mutants \
                                 .pytest_cache \
                                 test-results.xml \
                                 integration-test-results.xml \
@@ -71,18 +76,24 @@ pipeline {
                     docker run --rm \
                         -u $(id -u):$(id -g) \
                         -e CI=true \
+                        -e PYTHONPATH=/workspace \
                         -v "$WORKSPACE:/workspace" \
                         -w /workspace \
                         ${CI_IMAGE} \
-                        sh -c "
+                        sh -c '
+                            COVERAGE_GATE=$(python tools/quality_gates.py coverage)
+
                             pytest test.py -v \
                                 --tb=short \
                                 --junitxml=test-results.xml \
-                                --cov=. \
+                                --cov=main \
+                                --cov=schemas \
+                                --cov-branch \
                                 --cov-report=xml \
                                 --cov-report=html:coverage-report \
-                                -m 'not integration'
-                        "
+                                --cov-fail-under="${COVERAGE_GATE}" \
+                                -m "not integration"
+                        '
                 '''
             }
         }
@@ -95,6 +106,7 @@ pipeline {
                     docker run --rm \
                         -u $(id -u):$(id -g) \
                         -e CI=true \
+                        -e PYTHONPATH=/workspace \
                         -v "$WORKSPACE:/workspace" \
                         -w /workspace \
                         ${CI_IMAGE} \
@@ -116,6 +128,7 @@ pipeline {
                     docker run --rm \
                         -u $(id -u):$(id -g) \
                         -e CI=true \
+                        -e PYLINTHOME=/workspace/.pylint_cache \
                         -v "$WORKSPACE:/workspace" \
                         -w /workspace \
                         ${CI_IMAGE} \
@@ -131,12 +144,93 @@ pipeline {
                                 > pylint-files.txt
 
                             if [ -s pylint-files.txt ]; then
+                                # Generiamo il report
                                 xargs pylint --exit-zero --output-format=parseable < pylint-files.txt > pylint-report.txt
+                                # Stampiamo il risultato nel log di Jenkins per visibilità immediata
+                                echo "--- PYLINT REPORT START ---"
+                                cat pylint-report.txt
+                                echo "--- PYLINT REPORT END ---"
                             else
                                 echo "No Python files found for pylint" > pylint-report.txt
                             fi
                         '
-                    exit 0
+                '''
+
+//                 // TENTATIVO DI USARE IL PLUGIN (Warnings Next Generation)
+//                 script {
+//                     try {
+//                         recordIssues(tools: [pyLint(pattern: 'pylint-report.txt'), flake8(pattern: 'flake8-report.json')])
+//                     } catch (Exception e) {
+//                         echo "⚠️ Plugin 'Warnings Next Generation' non trovato. Salto la generazione dei grafici."
+//                     }
+//                 }
+            }
+        }
+
+        stage('Mutation Testing') {
+            steps {
+                echo "🧬 Running mutation test analysis..."
+                sh '''
+                    set +e
+                    docker run --rm \
+                        -u $(id -u):$(id -g) \
+                        -e CI=true \
+                        -v "$WORKSPACE:/workspace" \
+                        -w /workspace \
+                        ${CI_IMAGE} \
+                        sh -c '
+                            set +e
+
+                            mutmut --version
+
+                            mutmut run --max-children 4
+                            MUTMUT_EXIT=$?
+                            echo "mutmut exit code: ${MUTMUT_EXIT}"
+
+                            python tools/mutation_report.py || true
+                            mutmut export-cicd-stats || true
+
+                            echo "--- MUTATION REPORT FILES START ---"
+                            find mutation-report -maxdepth 2 -type f -print || true
+                            echo "--- MUTATION REPORT FILES END ---"
+
+                            echo "--- MUTATION TEST SUMMARY START ---"
+                            if [ -f mutants/mutmut-cicd-stats.json ]; then
+                                cat mutants/mutmut-cicd-stats.json
+                            else
+                                echo "No mutation stats generated"
+                            fi
+                            echo "--- MUTATION TEST SUMMARY END ---"
+
+                            # Quality gate futuro, intenzionalmente disabilitato mentre fissiamo la baseline.
+                            # Soglie suggerite:
+                            # 1. score >= 55 dopo aver coperto i cluster principali di survivor.
+                            # 2. score >= 65 quando sectoral/loader avranno test piu forti.
+                            # 3. score >= 70 solo sul profilo mutmut selezionato, non su tutto il progetto.
+                            #
+                            # python - <<'"'"'PY'"'"'
+                            # import json
+                            # from pathlib import Path
+                            #
+                            # stats_path = Path("mutants/mutmut-cicd-stats.json")
+                            # if not stats_path.exists():
+                            #     raise SystemExit("Mutation stats file missing")
+                            #
+                            # stats = json.loads(stats_path.read_text())
+                            # killed = stats.get("killed", 0)
+                            # survived = stats.get("survived", 0)
+                            # effective = killed + survived
+                            # score = (killed / effective * 100) if effective else 0.0
+                            #
+                            # threshold = 55.0
+                            # if score < threshold:
+                            #     raise SystemExit(
+                            #         f"Mutation score {score:.1f}% is below threshold {threshold:.1f}%"
+                            #     )
+                            # PY
+
+                            exit 0
+                        '
                 '''
             }
         }
@@ -146,6 +240,60 @@ pipeline {
         always {
             echo "📝 Publishing test results..."
             junit allowEmptyResults: true, testResults: '*test-results.xml'
+
+            sh '''
+                set +e
+                if docker image inspect ${CI_IMAGE} >/dev/null 2>&1; then
+                    docker run --rm \
+                        -u $(id -u):$(id -g) \
+                        -e BUILD_URL="${BUILD_URL}" \
+                        -e GIT_COMMIT="${GIT_COMMIT}" \
+                        -e BRANCH_NAME="${BRANCH_NAME}" \
+                        -e CHANGE_ID="${CHANGE_ID}" \
+                        -e CHANGE_BRANCH="${CHANGE_BRANCH}" \
+                        -e CHANGE_TARGET="${CHANGE_TARGET}" \
+                        -e JOB_NAME="${JOB_NAME}" \
+                        -v "$WORKSPACE:/workspace" \
+                        -w /workspace \
+                        ${CI_IMAGE} \
+                        sh -c "python tools/test_report.py && python tools/quality_dashboard.py" || true
+                else
+                    echo "CI image ${CI_IMAGE} not available; skipping quality dashboard generation."
+                fi
+            '''
+
+            // QUESTA RIGA È QUELLA CHE TI FA VEDERE I RISULTATI NELLA DASHBOARD
+            archiveArtifacts artifacts: 'quality-dashboard/**, test-report/**, coverage.xml, coverage-report/**, pylint-report.txt, flake8-report.json, mutation-report/**, mutants/mutmut-cicd-stats.json', allowEmptyArchive: true
+
+            script {
+                try {
+                    withCredentials([usernamePassword(credentialsId: env.GITHUB_STATUS_CREDENTIALS_ID, usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN')]) {
+                        sh '''
+                            set +e
+                            if docker image inspect ${CI_IMAGE} >/dev/null 2>&1; then
+                                docker run --rm \
+                                    -u $(id -u):$(id -g) \
+                                    -e BUILD_URL="${BUILD_URL}" \
+                                    -e GIT_COMMIT="${GIT_COMMIT}" \
+                                    -e BRANCH_NAME="${BRANCH_NAME}" \
+                                    -e CHANGE_ID="${CHANGE_ID}" \
+                                    -e CHANGE_BRANCH="${CHANGE_BRANCH}" \
+                                    -e CHANGE_TARGET="${CHANGE_TARGET}" \
+                                    -e JOB_NAME="${JOB_NAME}" \
+                                    -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
+                                    -v "$WORKSPACE:/workspace" \
+                                    -w /workspace \
+                                    ${CI_IMAGE} \
+                                    sh -c "python tools/github_statuses.py" || true
+                            else
+                                echo "CI image ${CI_IMAGE} not available; skipping GitHub commit statuses."
+                            fi
+                        '''
+                    }
+                } catch (Exception e) {
+                    echo "GitHub commit statuses skipped: ${e.getMessage()}"
+                }
+            }
 
             sh '''
                 docker image rm -f ${CI_IMAGE} 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ If Tracker is down or slow, Projector behavior will also be affected.
 
 Detailed documentation is available in the `/docs` folder:
 
+* `CONTRIBUTING.md`
 * `docs/overview.md`
 * `docs/api-reference.md`
 * `docs/data-model.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ It is designed for three audiences:
 ## Suggested reading order
 
 ### Section index
+- [Contributing and quality workflow](../CONTRIBUTING.md)
 - [Overview document](./overview.md)
 - [API reference document](./api-reference.md)
 - [Data model document](./data-model.md)
@@ -30,12 +31,13 @@ It is designed for three audiences:
 - [Examples document](./examples.md)
 - [Issue management document](./issue-management.md)
 
-1. **[overview.md](./overview.md)** — what the service is, what problem it solves, and when to use it  
-2. **[api-reference.md](./api-reference.md)** — endpoint-by-endpoint reference  
-3. **[data-model.md](./data-model.md)** — meaning of fields and metrics returned by the API  
-4. **[architecture.md](./architecture.md)** — internal flow, Tracker dependency, caching, stop behavior, and caveats  
-5. **[examples.md](./examples.md)** — ready-to-use request/response examples and integration patterns  
-6. **[issue-management.md](./issue-management.md)** — issue labels, GitHub Project statuses, templates, and decision/implementation flows
+1. **[../CONTRIBUTING.md](../CONTRIBUTING.md)** — development flow, Jenkins, GitHub checks, quality gates and generated reports
+2. **[overview.md](./overview.md)** — what the service is, what problem it solves, and when to use it
+3. **[api-reference.md](./api-reference.md)** — endpoint-by-endpoint reference
+4. **[data-model.md](./data-model.md)** — meaning of fields and metrics returned by the API
+5. **[architecture.md](./architecture.md)** — internal flow, Tracker dependency, caching, stop behavior, and caveats
+6. **[examples.md](./examples.md)** — ready-to-use request/response examples and integration patterns
+7. **[issue-management.md](./issue-management.md)** — issue labels, GitHub Project statuses, templates, and decision/implementation flows
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,56 @@
+[tool.mutmut]
+paths_to_mutate = [
+    "main.py",
+    "schemas.py",
+]
+also_copy = [
+    "test.py",
+]
+tests_dir = ["test.py"]
+pytest_add_cli_args_test_selection = [
+    "-m",
+    "not integration",
+]
+pytest_add_cli_args = ["-q"]
+mutate_only_covered_lines = true
+
+[tool.coverage.run]
+branch = true
+source = [
+    "main",
+    "schemas",
+]
+omit = [
+    "test.py",
+]
+
+[tool.coverage.report]
+precision = 1
+show_missing = true
+
+[tool.quality_gates]
+coverage = 70
+mutation_advisory = 55
+
+[tool.quality_checks.tests]
+label = "Pytest"
+mode = "Enforced"
+jenkins_result = "SUCCESS when pytest exits with code 0"
+rule = "Controlled by pytest exit code in Jenkins"
+
+[tool.quality_checks.coverage]
+label = "Coverage"
+mode = "Enforced"
+jenkins_result = "SUCCESS when coverage gate passes"
+rule = "Total coverage must meet the configured coverage gate"
+
+[tool.quality_checks.mutation]
+label = "Mutation"
+mode = "Advisory"
+jenkins_result = "SUCCESS when mutation analysis and reports are generated"
+
+[tool.quality_checks.lint]
+label = "Lint"
+mode = "Report only"
+jenkins_result = "SUCCESS when lint reports are generated"
+rule = "Reports are archived; no blocking gate configured"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    integration: tests that exercise integration-level FastAPI or external-service flows

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest-cov
+mutmut==3.5.0

--- a/test.py
+++ b/test.py
@@ -384,6 +384,7 @@ async def test_fetch_occupation_labels_specific_esco():
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
 @pytest.mark.skipif(
     os.getenv("CI") == "true",
     reason="Skipping test in CI environment"

--- a/tools/github_statuses.py
+++ b/tools/github_statuses.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import re
+import subprocess
+import urllib.error
+import urllib.request
+
+from quality_dashboard import parse_coverage, parse_junit, parse_mutation, pct
+from quality_gates import load_check_policies, load_gates
+
+
+MAX_DESCRIPTION = 140
+
+
+def run_git(*args):
+    return subprocess.check_output(["git", *args], text=True).strip()
+
+
+def infer_repo():
+    remote = run_git("config", "--get", "remote.origin.url")
+    match = re.search(r"github\.com[:/](?P<repo>[^/]+/[^/.]+)(?:\.git)?$", remote)
+    if not match:
+        raise ValueError(f"Cannot infer GitHub repository from remote URL: {remote}")
+    return match.group("repo")
+
+
+def infer_sha():
+    return os.environ.get("GIT_COMMIT") or run_git("rev-parse", "HEAD")
+
+
+def artifact_url(path):
+    build_url = os.environ.get("JENKINS_ARTIFACT_BASE_URL") or os.environ.get("BUILD_URL", "")
+    build_url = build_url.rstrip("/")
+    if not build_url:
+        return None
+    return f"{build_url}/artifact/{path}"
+
+
+def build_mode():
+    if not os.environ.get("CHANGE_ID"):
+        return "Branch"
+
+    marker_source = " ".join(
+        os.environ.get(name, "")
+        for name in ("JOB_NAME", "BUILD_URL", "BRANCH_NAME")
+    ).lower()
+    if "merge" in marker_source:
+        return "PR merge"
+    if "head" in marker_source:
+        return "PR head"
+    return "PR"
+
+
+def describe(message):
+    return f"{build_mode()}: {message}"
+
+
+def clamp_description(value):
+    value = " ".join(str(value).split())
+    return value[:MAX_DESCRIPTION]
+
+
+def post_status(repo, sha, token, context, state, description, target_url=None):
+    payload = {
+        "state": state,
+        "context": context,
+        "description": clamp_description(description),
+    }
+    if target_url:
+        payload["target_url"] = target_url
+
+    request = urllib.request.Request(
+        f"https://api.github.com/repos/{repo}/statuses/{sha}",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "User-Agent": "projector-jenkins-quality-statuses",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=20) as response:
+        response.read()
+
+
+def tests_status():
+    suites = [
+        parse_junit("test-results.xml", "Unit tests"),
+        parse_junit("integration-test-results.xml", "Integration tests"),
+    ]
+    if any(not suite.exists for suite in suites):
+        missing = ", ".join(suite.label for suite in suites if not suite.exists)
+        return ("error", describe(f"Missing JUnit report: {missing}"), artifact_url("test-report/index.html"))
+
+    total = sum(suite.tests for suite in suites)
+    failed = sum(suite.failures + suite.errors for suite in suites)
+    skipped = sum(suite.skipped for suite in suites)
+    passed = sum(suite.passed for suite in suites)
+    state = "failure" if failed else "success"
+    return (
+        state,
+        describe(f"Tests: {passed}/{total} passed, {failed} failed/errors, {skipped} skipped"),
+        artifact_url("test-report/index.html"),
+    )
+
+
+def coverage_status(gates):
+    coverage = parse_coverage("coverage.xml")
+    if not coverage.get("exists"):
+        return ("error", describe("Missing coverage.xml"), artifact_url("quality-dashboard/index.html"))
+
+    value = coverage["total_rate"] * 100
+    gate = gates["coverage"]
+    state = "success" if value >= gate else "failure"
+    description = describe(f"Coverage: {value:.1f}% / gate {gate:g}%; branch {coverage['branch_rate'] * 100:.1f}%")
+    return (state, description, artifact_url("coverage-report/index.html") or artifact_url("quality-dashboard/index.html"))
+
+
+def mutation_status(gates):
+    mutation = parse_mutation("mutants/mutmut-cicd-stats.json")
+    if not mutation.get("exists"):
+        return ("error", describe("Missing mutation stats"), artifact_url("quality-dashboard/index.html"))
+
+    value = mutation["score"] * 100
+    advisory = gates["mutation_advisory"]
+    relation = "meets" if value >= advisory else "below"
+    description = describe(
+        f"Mutation: {value:.1f}% {relation} advisory {advisory:g}%; "
+        f"killed {mutation.get('killed', 0)}, survived {mutation.get('survived', 0)}"
+    )
+    return ("success", description, artifact_url("mutation-report/index.html") or artifact_url("quality-dashboard/index.html"))
+
+
+def code_quality_status(check_policies):
+    has_pylint = os.path.exists("pylint-report.txt")
+    has_flake8 = os.path.exists("flake8-report.json")
+    if not has_pylint and not has_flake8:
+        return ("error", describe("Missing lint reports"), artifact_url("quality-dashboard/index.html"))
+    return ("success", describe(check_policies["lint"]["rule"]), artifact_url("quality-dashboard/index.html"))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Publish compact Jenkins quality statuses to a GitHub commit.")
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY"), help="GitHub repo in owner/name form.")
+    parser.add_argument("--sha", default=os.environ.get("GIT_COMMIT"), help="Commit SHA to update.")
+    parser.add_argument("--config", default="pyproject.toml")
+    args = parser.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("GITHUB_TOKEN not set; skipping GitHub commit statuses.")
+        return
+
+    repo = args.repo or infer_repo()
+    sha = args.sha or infer_sha()
+    gates = load_gates(args.config)
+    check_policies = load_check_policies(args.config)
+
+    statuses = [
+        ("Jenkins / Tests", *tests_status()),
+        ("Jenkins / Coverage Gate", *coverage_status(gates)),
+        ("Jenkins / Mutation Advisory", *mutation_status(gates)),
+        ("Jenkins / Code Quality", *code_quality_status(check_policies)),
+    ]
+
+    for context, state, description, target_url in statuses:
+        try:
+            post_status(repo, sha, token, context, state, description, target_url)
+            print(f"Published {context}: {state} - {description}")
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            print(f"Failed to publish {context}: HTTP {exc.code} {body}")
+        except Exception as exc:
+            print(f"Failed to publish {context}: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/mutation_report.py
+++ b/tools/mutation_report.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+import argparse
+import html
+import json
+import re
+from collections import Counter, defaultdict
+from pathlib import Path
+
+
+REPORT_CSS = """
+:root {
+  color-scheme: light;
+  --bg: #f6f7f9;
+  --ink: #1f2328;
+  --muted: #667085;
+  --line: #d7dde5;
+  --panel: #ffffff;
+  --green: #237a4b;
+  --red: #b42318;
+  --amber: #a15c00;
+  --blue: #255c99;
+  --violet: #6654a8;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--ink);
+  line-height: 1.45;
+}
+a { color: var(--blue); text-decoration-thickness: 1px; text-underline-offset: 2px; }
+header {
+  padding: 32px clamp(18px, 4vw, 56px) 22px;
+  border-bottom: 1px solid var(--line);
+  background: #edf2f7;
+}
+main {
+  padding: 24px clamp(18px, 4vw, 56px) 48px;
+  display: grid;
+  gap: 24px;
+}
+h1, h2, h3 {
+  margin: 0;
+  letter-spacing: 0;
+}
+h1 { font-size: clamp(28px, 5vw, 44px); }
+h2 { font-size: 20px; margin-bottom: 12px; }
+h3 { font-size: 16px; margin-bottom: 10px; }
+.meta { color: var(--muted); margin-top: 8px; }
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 12px;
+}
+.card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 16px;
+}
+.card strong {
+  display: block;
+  font-size: 28px;
+  margin-bottom: 4px;
+}
+.card span { color: var(--muted); }
+section {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 18px;
+  overflow: auto;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+  min-width: 760px;
+}
+th, td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+  vertical-align: top;
+}
+th {
+  color: var(--muted);
+  font-weight: 650;
+  background: #fbfcfd;
+}
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+.score { font-weight: 700; color: var(--blue); }
+.pill {
+  display: inline-block;
+  min-width: 74px;
+  text-align: center;
+  padding: 3px 8px;
+  border-radius: 999px;
+  color: white;
+  font-size: 12px;
+  font-weight: 700;
+}
+.survived { background: var(--red); }
+.no_tests { background: var(--amber); }
+.pending { background: var(--muted); }
+.killed { background: var(--green); }
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
+}
+.nav a {
+  display: inline-block;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--panel);
+  padding: 7px 12px;
+  color: var(--ink);
+  text-decoration: none;
+}
+.nav a.current {
+  border-color: var(--blue);
+  color: white;
+  background: var(--blue);
+}
+.note {
+  border-left: 4px solid var(--violet);
+  padding: 10px 12px;
+  background: #f4f2fb;
+  color: #35304f;
+}
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+.compact { min-width: 0; }
+""".strip()
+
+
+def mutant_status(exit_code):
+    if exit_code is None:
+        return "pending"
+    if exit_code == 0:
+        return "survived"
+    if exit_code == 33:
+        return "no_tests"
+    return "killed"
+
+
+def parse_mutant_name(name):
+    match = re.search(r"\.x.(?P<class>[^.]+).(?P<func>.*?)__mutmut_(?P<num>\d+)$", name)
+    if not match:
+        return "", "", ""
+    return match.group("class"), match.group("func"), match.group("num")
+
+
+def load_mutants(mutants_dir):
+    mutants = []
+    for meta_path in sorted(mutants_dir.glob("**/*.meta")):
+        source_file = meta_path.relative_to(mutants_dir).as_posix()[:-5]
+        with meta_path.open(encoding="utf-8") as fh:
+            data = json.load(fh)
+        for name, exit_code in data.get("exit_code_by_key", {}).items():
+            class_name, function_name, mutant_number = parse_mutant_name(name)
+            status = mutant_status(exit_code)
+            mutants.append(
+                {
+                    "name": name,
+                    "file": source_file,
+                    "class": class_name,
+                    "function": function_name,
+                    "number": mutant_number,
+                    "status": status,
+                }
+            )
+    return mutants
+
+
+def pct(killed, survived):
+    total = killed + survived
+    if total == 0:
+        return "0.0"
+    return f"{(killed / total) * 100:.1f}"
+
+
+def slug(value):
+    return re.sub(r"[^a-zA-Z0-9._-]+", "-", value).strip("-")
+
+
+def e(value):
+    return html.escape(str(value))
+
+
+def page(title, current, body, depth=0):
+    prefix = "../" * depth
+    nav = [
+        ("Overview", f"{prefix}index.html", "overview"),
+        ("Survived", f"{prefix}status-survived.html", "survived"),
+        ("No tests", f"{prefix}status-no_tests.html", "no_tests"),
+        ("Pending", f"{prefix}status-pending.html", "pending"),
+    ]
+    nav_links = "\n".join(
+        f'<a class="{"current" if key == current else ""}" href="{href}">{label}</a>'
+        for label, href, key in nav
+    )
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{e(title)}</title>
+  <link rel="stylesheet" href="{prefix}report.css">
+</head>
+<body>
+  <header>
+    <h1>{e(title)}</h1>
+    <div class="meta">Generated from <code>mutants/*.meta</code>. Mutation score excludes no-test and pending mutants.</div>
+    <nav class="nav">{nav_links}</nav>
+  </header>
+  <main>{body}</main>
+</body>
+</html>
+"""
+
+
+def aggregate(mutants):
+    totals = Counter(m["status"] for m in mutants)
+    by_file = defaultdict(Counter)
+    by_function = defaultdict(Counter)
+    by_file_function = defaultdict(lambda: defaultdict(Counter))
+    for mutant in mutants:
+        by_file[mutant["file"]][mutant["status"]] += 1
+        function_name = f'{mutant["class"]}.{mutant["function"]}'
+        function_key = f'{mutant["file"]}::{function_name}'
+        by_function[function_key][mutant["status"]] += 1
+        by_file_function[mutant["file"]][function_name][mutant["status"]] += 1
+    return totals, by_file, by_function, by_file_function
+
+
+def status_pill(status):
+    return f'<span class="pill {e(status)}">{e(status)}</span>'
+
+
+def cards(totals):
+    killed = totals["killed"]
+    survived = totals["survived"]
+    effective_total = killed + survived
+    score = pct(killed, survived)
+    return f"""
+    <div class="cards">
+      <div class="card"><strong>{score}%</strong><span>mutation score</span></div>
+      <div class="card"><strong>{effective_total}</strong><span>effective mutants</span></div>
+      <div class="card"><strong>{killed}</strong><span>killed</span></div>
+      <div class="card"><strong>{survived}</strong><span>survived</span></div>
+      <div class="card"><strong>{totals['no_tests']}</strong><span>no tests</span></div>
+      <div class="card"><strong>{totals['pending']}</strong><span>pending</span></div>
+    </div>
+    """
+
+
+def file_summary_rows(by_file):
+    rows = []
+    for source_file, counts in sorted(by_file.items()):
+        file_score = pct(counts["killed"], counts["survived"])
+        detail = f"files/{slug(source_file)}.html"
+        rows.append(
+            f"""
+            <tr>
+              <td><a href="{e(detail)}">{e(source_file)}</a></td>
+              <td>{sum(counts.values())}</td>
+              <td>{counts['killed']}</td>
+              <td>{counts['survived']}</td>
+              <td>{counts['no_tests']}</td>
+              <td>{counts['pending']}</td>
+              <td><span class="score">{file_score}%</span></td>
+            </tr>
+            """
+        )
+    return "".join(rows)
+
+
+def cluster_rows(by_function, limit=40):
+    rows = []
+    clusters = sorted(
+        by_function.items(),
+        key=lambda item: (item[1]["survived"], item[1]["no_tests"], sum(item[1].values())),
+        reverse=True,
+    )
+    for function_key, counts in clusters[:limit]:
+        cluster_score = pct(counts["killed"], counts["survived"])
+        source_file = function_key.split("::", 1)[0]
+        detail = f"files/{slug(source_file)}.html"
+        rows.append(
+            f"""
+            <tr>
+              <td><a href="{e(detail)}">{e(function_key)}</a></td>
+              <td>{sum(counts.values())}</td>
+              <td>{counts['killed']}</td>
+              <td>{counts['survived']}</td>
+              <td>{counts['no_tests']}</td>
+              <td><span class="score">{cluster_score}%</span></td>
+            </tr>
+            """
+        )
+    return "".join(rows)
+
+
+def mutant_rows(mutants, link_prefix="files/"):
+    rows = []
+    for mutant in sorted(mutants, key=lambda m: (m["status"], m["file"], m["function"], m["number"])):
+        command = f"mutmut show {mutant['name']}"
+        detail = f"{link_prefix}{slug(mutant['file'])}.html"
+        rows.append(
+            f"""
+            <tr>
+              <td>{status_pill(mutant['status'])}</td>
+              <td><a href="{e(detail)}">{e(mutant['file'])}</a></td>
+              <td>{e(mutant['class'])}.{e(mutant['function'])}</td>
+              <td><code>{e(mutant['name'])}</code></td>
+              <td><code>{e(command)}</code></td>
+            </tr>
+            """
+        )
+    return "".join(rows)
+
+
+def render_index(mutants):
+    totals, by_file, by_function, _ = aggregate(mutants)
+    actionable = [m for m in mutants if m["status"] in {"survived", "no_tests", "pending"}]
+    body = f"""
+    {cards(totals)}
+    <section class="note compact">
+      <strong>Overview first.</strong>
+      This page contains the quality snapshot, file health, largest survivor clusters, and all actionable mutants.
+      Use file links only when you need deeper detail for a specific source file.
+    </section>
+    <section>
+      <h2>Files</h2>
+      <table>
+        <thead><tr><th>File</th><th>Total</th><th>Killed</th><th>Survived</th><th>No Tests</th><th>Pending</th><th>Score</th></tr></thead>
+        <tbody>{file_summary_rows(by_file)}</tbody>
+      </table>
+    </section>
+    <section>
+      <h2>Largest Survivor Clusters</h2>
+      <table>
+        <thead><tr><th>Function</th><th>Total</th><th>Killed</th><th>Survived</th><th>No Tests</th><th>Score</th></tr></thead>
+        <tbody>{cluster_rows(by_function)}</tbody>
+      </table>
+    </section>
+    <section>
+      <h2>Actionable Mutants</h2>
+      <table>
+        <thead><tr><th>Status</th><th>File</th><th>Function</th><th>Mutant</th><th>Inspect</th></tr></thead>
+        <tbody>{mutant_rows(actionable)}</tbody>
+      </table>
+    </section>
+    """
+    return page("Mutation Test Report", "overview", body)
+
+
+def render_status_page(mutants, status):
+    filtered = [m for m in mutants if m["status"] == status]
+    body = f"""
+    <section>
+      <h2>{e(status)} mutants</h2>
+      <table>
+        <thead><tr><th>Status</th><th>File</th><th>Function</th><th>Mutant</th><th>Inspect</th></tr></thead>
+        <tbody>{mutant_rows(filtered)}</tbody>
+      </table>
+    </section>
+    """
+    return page(f"Mutation Report: {status}", status, body)
+
+
+def render_file_page(source_file, file_mutants, function_counts):
+    counts = Counter(m["status"] for m in file_mutants)
+    score = pct(counts["killed"], counts["survived"])
+    function_rows = []
+    for function_name, fn_counts in sorted(
+        function_counts.items(),
+        key=lambda item: (item[1]["survived"], item[1]["no_tests"], sum(item[1].values())),
+        reverse=True,
+    ):
+        function_rows.append(
+            f"""
+            <tr>
+              <td>{e(function_name)}</td>
+              <td>{sum(fn_counts.values())}</td>
+              <td>{fn_counts['killed']}</td>
+              <td>{fn_counts['survived']}</td>
+              <td>{fn_counts['no_tests']}</td>
+              <td><span class="score">{pct(fn_counts['killed'], fn_counts['survived'])}%</span></td>
+            </tr>
+            """
+        )
+    body = f"""
+    <div class="cards">
+      <div class="card"><strong>{score}%</strong><span>file mutation score</span></div>
+      <div class="card"><strong>{sum(counts.values())}</strong><span>total mutants</span></div>
+      <div class="card"><strong>{counts['killed']}</strong><span>killed</span></div>
+      <div class="card"><strong>{counts['survived']}</strong><span>survived</span></div>
+      <div class="card"><strong>{counts['no_tests']}</strong><span>no tests</span></div>
+    </div>
+    <section>
+      <h2>Function Summary</h2>
+      <table>
+        <thead><tr><th>Function</th><th>Total</th><th>Killed</th><th>Survived</th><th>No Tests</th><th>Score</th></tr></thead>
+        <tbody>{''.join(function_rows)}</tbody>
+      </table>
+    </section>
+    <section>
+      <h2>All Mutants In This File</h2>
+      <table>
+        <thead><tr><th>Status</th><th>File</th><th>Function</th><th>Mutant</th><th>Inspect</th></tr></thead>
+        <tbody>{mutant_rows(file_mutants, link_prefix="")}</tbody>
+      </table>
+    </section>
+    """
+    return page(f"Mutation Detail: {source_file}", "overview", body, depth=1)
+
+
+def write_report(mutants, output):
+    output.parent.mkdir(parents=True, exist_ok=True)
+    report_dir = output.parent
+    files_dir = report_dir / "files"
+    files_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "report.css").write_text(REPORT_CSS + "\n", encoding="utf-8")
+    output.write_text(render_index(mutants), encoding="utf-8")
+
+    for status in ("survived", "no_tests", "pending"):
+        (report_dir / f"status-{status}.html").write_text(render_status_page(mutants, status), encoding="utf-8")
+
+    _, _, _, by_file_function = aggregate(mutants)
+    by_file_mutants = defaultdict(list)
+    for mutant in mutants:
+        by_file_mutants[mutant["file"]].append(mutant)
+
+    for source_file, file_mutants in by_file_mutants.items():
+        detail_path = files_dir / f"{slug(source_file)}.html"
+        detail_path.write_text(
+            render_file_page(source_file, file_mutants, by_file_function[source_file]),
+            encoding="utf-8",
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate a Jenkins-friendly HTML report from mutmut metadata.")
+    parser.add_argument("--mutants-dir", default="mutants", help="Directory created by mutmut.")
+    parser.add_argument("--output", default="mutation-report/index.html", help="Output HTML path.")
+    args = parser.parse_args()
+
+    mutants_dir = Path(args.mutants_dir)
+    output = Path(args.output)
+    mutants = load_mutants(mutants_dir)
+    if not mutants:
+        raise SystemExit(f"No mutmut metadata found under {mutants_dir}. Run mutmut first.")
+
+    write_report(mutants, output)
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/quality_dashboard.py
+++ b/tools/quality_dashboard.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+import argparse
+import html
+import json
+import os
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+
+from quality_gates import load_check_policies, load_gates
+
+
+DASHBOARD_CSS = """
+:root {
+  color-scheme: light;
+  --bg: #f5f7fa;
+  --panel: #ffffff;
+  --ink: #1f2328;
+  --muted: #667085;
+  --line: #d7dde5;
+  --green: #237a4b;
+  --red: #b42318;
+  --amber: #a15c00;
+  --blue: #255c99;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--ink);
+  line-height: 1.45;
+}
+a { color: var(--blue); text-decoration-thickness: 1px; text-underline-offset: 2px; }
+header {
+  padding: 32px clamp(18px, 4vw, 56px) 24px;
+  border-bottom: 1px solid var(--line);
+  background: #eef3f8;
+}
+main {
+  padding: 24px clamp(18px, 4vw, 56px) 48px;
+  display: grid;
+  gap: 24px;
+}
+h1, h2 { margin: 0; letter-spacing: 0; }
+h1 { font-size: clamp(28px, 5vw, 44px); }
+h2 { font-size: 20px; margin-bottom: 12px; }
+.meta { color: var(--muted); margin-top: 8px; }
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+.card, section {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+.card { padding: 16px; }
+.card strong {
+  display: block;
+  font-size: 28px;
+  margin-bottom: 4px;
+}
+.card span { color: var(--muted); }
+section { padding: 18px; overflow: auto; }
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+  min-width: 700px;
+}
+th, td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+  vertical-align: top;
+}
+th { color: var(--muted); background: #fbfcfd; }
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+}
+.pill {
+  display: inline-block;
+  min-width: 76px;
+  text-align: center;
+  padding: 3px 8px;
+  border-radius: 999px;
+  color: white;
+  font-size: 12px;
+  font-weight: 700;
+}
+.pass { background: var(--green); }
+.fail { background: var(--red); }
+.below { background: var(--amber); }
+.info { background: var(--blue); }
+.missing { background: var(--muted); }
+.links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.links a {
+  display: inline-block;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: #fff;
+  padding: 7px 12px;
+  color: var(--ink);
+  text-decoration: none;
+}
+""".strip()
+
+
+@dataclass
+class TestSummary:
+    label: str
+    path: str
+    exists: bool
+    tests: int = 0
+    failures: int = 0
+    errors: int = 0
+    skipped: int = 0
+    time: float = 0.0
+
+    @property
+    def passed(self):
+        return max(self.tests - self.failures - self.errors - self.skipped, 0)
+
+    @property
+    def status(self):
+        if not self.exists:
+            return "missing"
+        if self.failures or self.errors:
+            return "fail"
+        return "pass"
+
+
+def e(value):
+    return html.escape(str(value))
+
+
+def pct(value):
+    return f"{value * 100:.1f}%"
+
+
+def pill(status):
+    labels = {
+        "pass": "PASS",
+        "fail": "FAIL",
+        "below": "BELOW",
+        "info": "INFO",
+        "missing": "MISSING",
+    }
+    return f'<span class="pill {status}">{labels.get(status, status.upper())}</span>'
+
+
+def get_build_context():
+    change_id = os.environ.get("CHANGE_ID", "")
+    marker_source = " ".join(
+        os.environ.get(name, "")
+        for name in ("JOB_NAME", "BUILD_URL", "BRANCH_NAME")
+    ).lower()
+
+    if change_id:
+        if "merge" in marker_source:
+            mode = "PR merge"
+        elif "head" in marker_source:
+            mode = "PR head"
+        else:
+            mode = "PR"
+        scope = f"PR #{change_id}"
+        source = os.environ.get("CHANGE_BRANCH") or os.environ.get("BRANCH_NAME") or "unknown"
+        target = os.environ.get("CHANGE_TARGET") or "unknown"
+    else:
+        mode = "Branch"
+        scope = os.environ.get("BRANCH_NAME") or "unknown"
+        source = scope
+        target = ""
+
+    return {
+        "mode": mode,
+        "scope": scope,
+        "source": source,
+        "target": target,
+        "sha": os.environ.get("GIT_COMMIT", ""),
+        "build_url": os.environ.get("BUILD_URL", ""),
+    }
+
+
+def parse_junit(path, label):
+    file_path = Path(path)
+    if not file_path.exists():
+        return TestSummary(label=label, path=path, exists=False)
+
+    root = ET.parse(file_path).getroot()
+    suites = [root] if root.tag == "testsuite" else root.findall("testsuite")
+    summary = TestSummary(label=label, path=path, exists=True)
+    for suite in suites:
+        summary.tests += int(suite.attrib.get("tests", 0))
+        summary.failures += int(suite.attrib.get("failures", 0))
+        summary.errors += int(suite.attrib.get("errors", 0))
+        summary.skipped += int(suite.attrib.get("skipped", 0))
+        summary.time += float(suite.attrib.get("time", 0.0))
+    return summary
+
+
+def parse_coverage(path):
+    file_path = Path(path)
+    if not file_path.exists():
+        return {"exists": False}
+
+    root = ET.parse(file_path).getroot()
+    classes = []
+    for class_node in root.findall(".//class"):
+        filename = class_node.attrib.get("filename", "")
+        line_rate = float(class_node.attrib.get("line-rate", 0.0))
+        branch_rate = float(class_node.attrib.get("branch-rate", 0.0))
+        classes.append({"filename": filename, "line_rate": line_rate, "branch_rate": branch_rate})
+
+    lines_valid = int(root.attrib.get("lines-valid", 0))
+    lines_covered = int(root.attrib.get("lines-covered", 0))
+    branches_valid = int(root.attrib.get("branches-valid", 0))
+    branches_covered = int(root.attrib.get("branches-covered", 0))
+    total_valid = lines_valid + branches_valid
+    total_covered = lines_covered + branches_covered
+    total_rate = (total_covered / total_valid) if total_valid else 0.0
+
+    return {
+        "exists": True,
+        "total_rate": total_rate,
+        "line_rate": float(root.attrib.get("line-rate", 0.0)),
+        "branch_rate": float(root.attrib.get("branch-rate", 0.0)),
+        "lines_valid": lines_valid,
+        "lines_covered": lines_covered,
+        "branches_valid": branches_valid,
+        "branches_covered": branches_covered,
+        "worst_files": sorted(classes, key=lambda item: item["line_rate"])[:5],
+    }
+
+
+def parse_mutation(path):
+    file_path = Path(path)
+    if not file_path.exists():
+        return {"exists": False}
+
+    data = json.loads(file_path.read_text(encoding="utf-8"))
+    killed = int(data.get("killed", 0))
+    survived = int(data.get("survived", 0))
+    effective = killed + survived
+    score = (killed / effective) if effective else 0.0
+    return {"exists": True, "score": score, **data}
+
+
+def render_cards(tests, coverage, mutation, coverage_gate, mutation_advisory):
+    total_tests = sum(item.tests for item in tests if item.exists)
+    total_failed = sum(item.failures + item.errors for item in tests if item.exists)
+    total_skipped = sum(item.skipped for item in tests if item.exists)
+    total_passed = sum(item.passed for item in tests if item.exists)
+    coverage_value = coverage.get("total_rate", 0.0) if coverage.get("exists") else None
+    mutation_value = mutation.get("score", 0.0) if mutation.get("exists") else None
+
+    return f"""
+    <div class="cards">
+      <div class="card"><strong>{total_passed}/{total_tests}</strong><span>tests passed</span></div>
+      <div class="card"><strong>{total_failed}</strong><span>test failures/errors</span></div>
+      <div class="card"><strong>{total_skipped}</strong><span>tests skipped</span></div>
+      <div class="card"><strong>{pct(coverage_value) if coverage_value is not None else "missing"}</strong><span>coverage, gate {coverage_gate:.0f}%</span></div>
+      <div class="card"><strong>{pct(mutation_value) if mutation_value is not None else "missing"}</strong><span>mutation, advisory {mutation_advisory:.0f}%</span></div>
+      <div class="card"><strong>{mutation.get("survived", "missing")}</strong><span>survived mutants</span></div>
+    </div>
+    """
+
+
+def render_build_context(context):
+    rows = [
+        ("Build mode", context["mode"]),
+        ("Scope", context["scope"]),
+        ("Source branch", context["source"]),
+    ]
+    if context["target"]:
+        rows.append(("Target branch", context["target"]))
+    if context["sha"]:
+        rows.append(("Commit", context["sha"][:12]))
+    if context["build_url"]:
+        rows.append(("Jenkins build", f'<a href="{e(context["build_url"])}">Open build</a>'))
+
+    body = "\n".join(
+        f"<tr><td>{e(label)}</td><td>{value if value.startswith('<a ') else e(value)}</td></tr>"
+        for label, value in rows
+    )
+    return f"""
+    <section>
+      <h2>Build Context</h2>
+      <table>
+        <tbody>{body}</tbody>
+      </table>
+    </section>
+    """
+
+
+def render_test_table(tests):
+    rows = []
+    for item in tests:
+        rows.append(
+            f"""
+            <tr>
+              <td>{e(item.label)}</td>
+              <td>{pill(item.status)}</td>
+              <td>{item.tests if item.exists else "missing"}</td>
+              <td>{item.passed if item.exists else "missing"}</td>
+              <td>{item.failures if item.exists else "missing"}</td>
+              <td>{item.errors if item.exists else "missing"}</td>
+              <td>{item.skipped if item.exists else "missing"}</td>
+              <td><code>{e(item.path)}</code></td>
+            </tr>
+            """
+        )
+    return f"""
+    <section>
+      <h2>Tests</h2>
+      <table>
+        <thead><tr><th>Suite</th><th>Status</th><th>Total</th><th>Passed</th><th>Failures</th><th>Errors</th><th>Skipped</th><th>Source</th></tr></thead>
+        <tbody>{''.join(rows)}</tbody>
+      </table>
+    </section>
+    """
+
+
+def render_gate_table(tests, coverage, mutation, coverage_gate, mutation_advisory, check_policies):
+    test_outcome = "fail" if any(item.status == "fail" for item in tests) else "pass"
+    if any(item.status == "missing" for item in tests):
+        test_outcome = "missing" if test_outcome == "pass" else test_outcome
+
+    if coverage.get("exists"):
+        coverage_outcome = "pass" if coverage["total_rate"] * 100 >= coverage_gate else "fail"
+        coverage_note = (
+            f'{check_policies["coverage"]["rule"]}: '
+            f'{pct(coverage["total_rate"])} >= {coverage_gate:.0f}%'
+        )
+    else:
+        coverage_outcome = "missing"
+        coverage_note = f'{check_policies["coverage"]["rule"]}: coverage.xml not found'
+
+    if mutation.get("exists"):
+        mutation_outcome = "pass" if mutation["score"] * 100 >= mutation_advisory else "below"
+        mutation_note = f'{pct(mutation["score"])} advisory threshold {mutation_advisory:.0f}%'
+    else:
+        mutation_outcome = "missing"
+        mutation_note = "mutmut stats not found"
+
+    rows = [
+        ("tests", test_outcome, test_outcome, check_policies["tests"]["rule"]),
+        ("coverage", coverage_outcome, coverage_outcome, coverage_note),
+        ("mutation", "pass" if mutation.get("exists") else "missing", mutation_outcome, mutation_note),
+        ("lint", "pass", "info", check_policies["lint"]["rule"]),
+    ]
+    body = "\n".join(
+        (
+            f"<tr><td>{e(check_policies[key]['label'])}</td><td>{pill(jenkins_result)}</td>"
+            f"<td>{e(check_policies[key]['jenkins_result'])}</td><td>{e(check_policies[key]['mode'])}</td>"
+            f"<td>{pill(quality_outcome)}</td><td>{e(note)}</td></tr>"
+        )
+        for key, jenkins_result, quality_outcome, note in rows
+    )
+    return f"""
+    <section>
+      <h2>Quality Gates</h2>
+      <table>
+        <thead><tr><th>Check</th><th>Jenkins Result</th><th>Jenkins Meaning</th><th>Quality Mode</th><th>Quality Outcome</th><th>Rule</th></tr></thead>
+        <tbody>{body}</tbody>
+      </table>
+    </section>
+    """
+
+
+def render_coverage(coverage, coverage_gate):
+    if not coverage.get("exists"):
+        return "<section><h2>Coverage</h2><p>coverage.xml missing.</p></section>"
+    rows = []
+    for item in coverage["worst_files"]:
+        rows.append(
+            f"""
+            <tr>
+              <td>{e(item["filename"])}</td>
+              <td>{pct(item["line_rate"])}</td>
+              <td>{pct(item["branch_rate"])}</td>
+            </tr>
+            """
+        )
+    return f"""
+    <section>
+      <h2>Coverage</h2>
+      <table>
+        <thead><tr><th>Metric</th><th>Value</th><th>Gate</th></tr></thead>
+        <tbody>
+          <tr><td>Total coverage</td><td>{pct(coverage["total_rate"])}</td><td>{coverage_gate:.0f}%</td></tr>
+          <tr><td>Line coverage</td><td>{pct(coverage["line_rate"])}</td><td>advisory</td></tr>
+          <tr><td>Branch coverage</td><td>{pct(coverage["branch_rate"])}</td><td>advisory</td></tr>
+          <tr><td>Lines</td><td>{coverage["lines_covered"]}/{coverage["lines_valid"]}</td><td></td></tr>
+          <tr><td>Branches</td><td>{coverage["branches_covered"]}/{coverage["branches_valid"]}</td><td></td></tr>
+        </tbody>
+      </table>
+      <h2>Lowest Coverage Files</h2>
+      <table>
+        <thead><tr><th>File</th><th>Line</th><th>Branch</th></tr></thead>
+        <tbody>{''.join(rows)}</tbody>
+      </table>
+    </section>
+    """
+
+
+def render_mutation(mutation, mutation_advisory):
+    if not mutation.get("exists"):
+        return "<section><h2>Mutation</h2><p>mutants/mutmut-cicd-stats.json missing.</p></section>"
+    rows = [
+        ("Score", pct(mutation["score"])),
+        ("Advisory threshold", f"{mutation_advisory:.0f}%"),
+        ("Killed", mutation.get("killed", 0)),
+        ("Survived", mutation.get("survived", 0)),
+        ("No tests", mutation.get("no_tests", 0)),
+        ("Skipped", mutation.get("skipped", 0)),
+        ("Timeout", mutation.get("timeout", 0)),
+        ("Suspicious", mutation.get("suspicious", 0)),
+    ]
+    body = "\n".join(f"<tr><td>{e(name)}</td><td>{e(value)}</td></tr>" for name, value in rows)
+    return f"""
+    <section>
+      <h2>Mutation</h2>
+      <table>
+        <thead><tr><th>Metric</th><th>Value</th></tr></thead>
+        <tbody>{body}</tbody>
+      </table>
+    </section>
+    """
+
+
+def render_links():
+    links = [
+        ("Test report", "../test-report/index.html"),
+        ("Coverage report", "../coverage-report/index.html"),
+        ("Mutation report", "../mutation-report/index.html"),
+        ("Mutation survived", "../mutation-report/status-survived.html"),
+        ("Pylint report", "../pylint-report.txt"),
+        ("Flake8 report", "../flake8-report.json"),
+    ]
+    items = "\n".join(f'<a href="{href}">{e(label)}</a>' for label, href in links)
+    return f"""
+    <section>
+      <h2>Detailed Reports</h2>
+      <div class="links">{items}</div>
+    </section>
+    """
+
+
+def render_dashboard(tests, coverage, mutation, coverage_gate, mutation_advisory, build_context, check_policies):
+    body = f"""
+    {render_cards(tests, coverage, mutation, coverage_gate, mutation_advisory)}
+    {render_build_context(build_context)}
+    {render_gate_table(tests, coverage, mutation, coverage_gate, mutation_advisory, check_policies)}
+    {render_test_table(tests)}
+    {render_coverage(coverage, coverage_gate)}
+    {render_mutation(mutation, mutation_advisory)}
+    {render_links()}
+    """
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>CI Quality Dashboard</title>
+  <link rel="stylesheet" href="report.css">
+</head>
+<body>
+  <header>
+    <h1>CI Quality Dashboard</h1>
+    <div class="meta">Read-only overview generated from Jenkins artifacts. Quality gates are enforced by Jenkins commands.</div>
+  </header>
+  <main>{body}</main>
+</body>
+</html>
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate a read-only CI quality dashboard.")
+    parser.add_argument("--output-dir", default="quality-dashboard")
+    parser.add_argument("--config", default="pyproject.toml")
+    parser.add_argument("--coverage-gate", type=float)
+    parser.add_argument("--mutation-advisory", type=float)
+    args = parser.parse_args()
+
+    gates = load_gates(args.config)
+    check_policies = load_check_policies(args.config)
+    coverage_gate = args.coverage_gate if args.coverage_gate is not None else gates["coverage"]
+    mutation_advisory = (
+        args.mutation_advisory if args.mutation_advisory is not None else gates["mutation_advisory"]
+    )
+
+    tests = [
+        parse_junit("test-results.xml", "Unit tests"),
+        parse_junit("integration-test-results.xml", "Integration tests"),
+    ]
+    coverage = parse_coverage("coverage.xml")
+    mutation = parse_mutation("mutants/mutmut-cicd-stats.json")
+    build_context = get_build_context()
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "report.css").write_text(DASHBOARD_CSS + "\n", encoding="utf-8")
+    (output_dir / "index.html").write_text(
+        render_dashboard(tests, coverage, mutation, coverage_gate, mutation_advisory, build_context, check_policies),
+        encoding="utf-8",
+    )
+    print(output_dir / "index.html")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/quality_gates.py
+++ b/tools/quality_gates.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+import argparse
+import copy
+import tomllib
+from pathlib import Path
+
+
+DEFAULT_GATES = {
+    "coverage": 78.0,
+    "mutation_advisory": 55.0,
+}
+
+DEFAULT_CHECK_POLICIES = {
+    "tests": {
+        "label": "Pytest",
+        "mode": "Enforced",
+        "jenkins_result": "SUCCESS when pytest exits with code 0",
+        "rule": "Controlled by pytest exit code in Jenkins",
+    },
+    "coverage": {
+        "label": "Coverage",
+        "mode": "Enforced",
+        "jenkins_result": "SUCCESS when coverage gate passes",
+        "rule": "Total coverage must meet the configured coverage gate",
+    },
+    "mutation": {
+        "label": "Mutation",
+        "mode": "Advisory",
+        "jenkins_result": "SUCCESS when mutation analysis and reports are generated",
+        "rule": "",
+    },
+    "lint": {
+        "label": "Lint",
+        "mode": "Report only",
+        "jenkins_result": "SUCCESS when lint reports are generated",
+        "rule": "Reports are archived; no blocking gate configured",
+    },
+}
+
+
+def load_tool_config(path):
+    config_path = Path(path)
+    if not config_path.exists():
+        return {}
+    return tomllib.loads(config_path.read_text(encoding="utf-8")).get("tool", {})
+
+
+def load_gates(path):
+    configured = load_tool_config(path).get("quality_gates", {})
+    gates = DEFAULT_GATES.copy()
+    for key in gates:
+        if key in configured:
+            gates[key] = float(configured[key])
+    return gates
+
+
+def load_check_policies(path):
+    configured = load_tool_config(path).get("quality_checks", {})
+    policies = copy.deepcopy(DEFAULT_CHECK_POLICIES)
+    for key, values in configured.items():
+        if key not in policies or not isinstance(values, dict):
+            continue
+        for field in ("label", "mode", "jenkins_result", "rule"):
+            if field in values:
+                policies[key][field] = str(values[field])
+    return policies
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Read quality gate thresholds from pyproject.toml.")
+    parser.add_argument("name", choices=sorted(DEFAULT_GATES))
+    parser.add_argument("--config", default="pyproject.toml")
+    args = parser.parse_args()
+
+    value = load_gates(args.config)[args.name]
+    print(f"{value:g}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_report.py
+++ b/tools/test_report.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+import argparse
+import html
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+REPORT_CSS = """
+:root {
+  color-scheme: light;
+  --bg: #f5f7fa;
+  --panel: #ffffff;
+  --ink: #1f2328;
+  --muted: #667085;
+  --line: #d7dde5;
+  --green: #237a4b;
+  --red: #b42318;
+  --amber: #a15c00;
+  --blue: #255c99;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--ink);
+  line-height: 1.45;
+}
+header {
+  padding: 32px clamp(18px, 4vw, 56px) 24px;
+  border-bottom: 1px solid var(--line);
+  background: #eef3f8;
+}
+main {
+  padding: 24px clamp(18px, 4vw, 56px) 48px;
+  display: grid;
+  gap: 24px;
+}
+h1, h2 { margin: 0; letter-spacing: 0; }
+h1 { font-size: clamp(28px, 5vw, 44px); }
+h2 { font-size: 20px; margin-bottom: 12px; }
+.meta { color: var(--muted); margin-top: 8px; }
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+.card, section {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+.card { padding: 16px; }
+.card strong {
+  display: block;
+  font-size: 28px;
+  margin-bottom: 4px;
+}
+.card span { color: var(--muted); }
+section { padding: 18px; overflow: auto; }
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+  min-width: 720px;
+}
+th, td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+  vertical-align: top;
+}
+th { color: var(--muted); background: #fbfcfd; }
+pre {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  background: #fbfcfd;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px;
+  margin: 8px 0 0;
+  font-size: 12px;
+}
+.pill {
+  display: inline-block;
+  min-width: 76px;
+  text-align: center;
+  padding: 3px 8px;
+  border-radius: 999px;
+  color: white;
+  font-size: 12px;
+  font-weight: 700;
+}
+.pass { background: var(--green); }
+.fail { background: var(--red); }
+.skip { background: var(--amber); }
+.missing { background: var(--muted); }
+""".strip()
+
+
+@dataclass
+class Case:
+    suite: str
+    classname: str
+    name: str
+    time: float
+    status: str = "passed"
+    message: str = ""
+    detail: str = ""
+
+
+@dataclass
+class Suite:
+    label: str
+    path: str
+    exists: bool
+    tests: int = 0
+    failures: int = 0
+    errors: int = 0
+    skipped: int = 0
+    time: float = 0.0
+    cases: list[Case] = field(default_factory=list)
+
+    @property
+    def passed(self):
+        return max(self.tests - self.failures - self.errors - self.skipped, 0)
+
+    @property
+    def status(self):
+        if not self.exists:
+            return "missing"
+        if self.failures or self.errors:
+            return "fail"
+        return "pass"
+
+
+def e(value):
+    return html.escape(str(value))
+
+
+def pill(status):
+    labels = {"pass": "PASS", "fail": "FAIL", "skip": "SKIPPED", "missing": "MISSING"}
+    return f'<span class="pill {status}">{labels.get(status, status.upper())}</span>'
+
+
+def parse_junit(path, label):
+    file_path = Path(path)
+    if not file_path.exists():
+        return Suite(label=label, path=path, exists=False)
+
+    root = ET.parse(file_path).getroot()
+    suite_nodes = [root] if root.tag == "testsuite" else root.findall("testsuite")
+    suite = Suite(label=label, path=path, exists=True)
+    for suite_node in suite_nodes:
+        suite_name = suite_node.attrib.get("name", label)
+        suite.tests += int(suite_node.attrib.get("tests", 0))
+        suite.failures += int(suite_node.attrib.get("failures", 0))
+        suite.errors += int(suite_node.attrib.get("errors", 0))
+        suite.skipped += int(suite_node.attrib.get("skipped", 0))
+        suite.time += float(suite_node.attrib.get("time", 0.0))
+
+        for case_node in suite_node.findall("testcase"):
+            case = Case(
+                suite=suite_name,
+                classname=case_node.attrib.get("classname", ""),
+                name=case_node.attrib.get("name", ""),
+                time=float(case_node.attrib.get("time", 0.0)),
+            )
+            failure = case_node.find("failure")
+            error = case_node.find("error")
+            skipped = case_node.find("skipped")
+            if failure is not None:
+                case.status = "failed"
+                case.message = failure.attrib.get("message", "")
+                case.detail = failure.text or ""
+            elif error is not None:
+                case.status = "error"
+                case.message = error.attrib.get("message", "")
+                case.detail = error.text or ""
+            elif skipped is not None:
+                case.status = "skipped"
+                case.message = skipped.attrib.get("message", "")
+                case.detail = skipped.text or ""
+            suite.cases.append(case)
+    return suite
+
+
+def render_cards(suites):
+    total = sum(suite.tests for suite in suites if suite.exists)
+    passed = sum(suite.passed for suite in suites if suite.exists)
+    failures = sum(suite.failures for suite in suites if suite.exists)
+    errors = sum(suite.errors for suite in suites if suite.exists)
+    skipped = sum(suite.skipped for suite in suites if suite.exists)
+    missing = sum(1 for suite in suites if not suite.exists)
+    return f"""
+    <div class="cards">
+      <div class="card"><strong>{passed}/{total}</strong><span>tests passed</span></div>
+      <div class="card"><strong>{failures}</strong><span>failures</span></div>
+      <div class="card"><strong>{errors}</strong><span>errors</span></div>
+      <div class="card"><strong>{skipped}</strong><span>skipped</span></div>
+      <div class="card"><strong>{missing}</strong><span>missing reports</span></div>
+    </div>
+    """
+
+
+def render_suite_table(suites):
+    rows = []
+    for suite in suites:
+        rows.append(
+            f"""
+            <tr>
+              <td>{e(suite.label)}</td>
+              <td>{pill(suite.status)}</td>
+              <td>{suite.tests if suite.exists else "missing"}</td>
+              <td>{suite.passed if suite.exists else "missing"}</td>
+              <td>{suite.failures if suite.exists else "missing"}</td>
+              <td>{suite.errors if suite.exists else "missing"}</td>
+              <td>{suite.skipped if suite.exists else "missing"}</td>
+              <td>{suite.time:.2f}s</td>
+              <td><code>{e(suite.path)}</code></td>
+            </tr>
+            """
+        )
+    return f"""
+    <section>
+      <h2>Suites</h2>
+      <table>
+        <thead><tr><th>Suite</th><th>Status</th><th>Total</th><th>Passed</th><th>Failures</th><th>Errors</th><th>Skipped</th><th>Time</th><th>Source</th></tr></thead>
+        <tbody>{''.join(rows)}</tbody>
+      </table>
+    </section>
+    """
+
+
+def render_problem_cases(suites):
+    cases = [case for suite in suites for case in suite.cases if case.status in {"failed", "error"}]
+    if not cases:
+        return "<section><h2>Failures And Errors</h2><p>No failed or errored tests.</p></section>"
+    rows = []
+    for case in cases:
+        rows.append(
+            f"""
+            <tr>
+              <td>{pill("fail")}</td>
+              <td>{e(case.classname)}::{e(case.name)}</td>
+              <td>{e(case.message)}<pre>{e(case.detail)}</pre></td>
+            </tr>
+            """
+        )
+    return f"""
+    <section>
+      <h2>Failures And Errors</h2>
+      <table>
+        <thead><tr><th>Status</th><th>Test</th><th>Message</th></tr></thead>
+        <tbody>{''.join(rows)}</tbody>
+      </table>
+    </section>
+    """
+
+
+def render_skipped_cases(suites):
+    cases = [case for suite in suites for case in suite.cases if case.status == "skipped"]
+    if not cases:
+        return "<section><h2>Skipped Tests</h2><p>No skipped tests.</p></section>"
+    rows = []
+    for case in cases:
+        rows.append(
+            f"""
+            <tr>
+              <td>{pill("skip")}</td>
+              <td>{e(case.classname)}::{e(case.name)}</td>
+              <td>{e(case.message)}</td>
+            </tr>
+            """
+        )
+    return f"""
+    <section>
+      <h2>Skipped Tests</h2>
+      <table>
+        <thead><tr><th>Status</th><th>Test</th><th>Reason</th></tr></thead>
+        <tbody>{''.join(rows)}</tbody>
+      </table>
+    </section>
+    """
+
+
+def render_report(suites):
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Test Report</title>
+  <link rel="stylesheet" href="report.css">
+</head>
+<body>
+  <header>
+    <h1>Test Report</h1>
+    <div class="meta">Generated from pytest JUnit output. XML files remain machine-readable artifacts; this page is for humans.</div>
+  </header>
+  <main>
+    {render_cards(suites)}
+    {render_suite_table(suites)}
+    {render_problem_cases(suites)}
+    {render_skipped_cases(suites)}
+  </main>
+</body>
+</html>
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate a human-readable HTML report from pytest JUnit XML files.")
+    parser.add_argument("--output-dir", default="test-report")
+    args = parser.parse_args()
+
+    suites = [
+        parse_junit("test-results.xml", "Unit tests"),
+        parse_junit("integration-test-results.xml", "Integration tests"),
+    ]
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "report.css").write_text(REPORT_CSS + "\n", encoding="utf-8")
+    (output_dir / "index.html").write_text(render_report(suites), encoding="utf-8")
+    print(output_dir / "index.html")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Introduces the CI/CD quality pipeline on top of the current `main` root layout.

This PR ports the quality tooling we validated on the feature branch, but adapts it to the current `main` structure:

- tests run from `test.py`;
- coverage targets `main.py` and `schemas.py`;
- mutmut targets `main.py` and `schemas.py`;
- generated quality artifacts are ignored and archived by Jenkins;
- GitHub commit statuses are published for tests, coverage, mutation advisory, and code quality;
- a read-only quality dashboard summarizes Jenkins result vs quality interpretation;
- `CONTRIBUTING.md` documents the branch flow, Jenkins pipeline, quality gates, GitHub checks, dashboards, and report locations.

## Notes

The real endpoint test is now marked as `integration`, so the non-integration suite does not depend on external Tracker credentials/endpoints. In CI it remains skipped through the existing `CI=true` guard.

Mutation testing is advisory and does not fail the pipeline while the baseline is being established.

## Validation

Executed locally in a temporary virtualenv with the dev requirements installed:

- `pytest test.py -m 'not integration' --tb=short --cov=main --cov=schemas --cov-branch --cov-report=term-missing --cov-fail-under=70`
  - `12 passed, 5 deselected`
  - total coverage `75.81%`, gate `70%`
- `CI=true pytest test.py -m 'integration' --tb=short`
  - `4 passed, 1 skipped, 12 deselected`
- `python -m py_compile` for the CI helper scripts
- `git diff --check`

Docker validation was not run locally because the Docker daemon is not available on this machine; Jenkins will validate the Docker-based pipeline.