### PR TITLE
Use tracker sectors for esco

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It provides:
 - top employers and job titles
 - emerging and declining skill trends
 - geographic and NUTS-like regional projections
-- optional sectoral intelligence for ISCO and NACE views
+- optional sectoral intelligence from Tracker API sectors
 
 The project also includes a Streamlit dashboard for exploring the API output.
 
@@ -83,7 +83,7 @@ The active backend flow is:
 app.main
  -> app.api.routes.projector
  -> app.services.projector_service.ProjectorService
- -> TrackerClient / analytics modules / ESCO loaders
+ -> TrackerClient / analytics modules
  -> app.schemas.responses
 ```
 
@@ -99,7 +99,7 @@ All endpoints currently accept `application/x-www-form-urlencoded` form data.
 
 ### Main Analysis
 
-`POST /projector/analyze-skills` fetches jobs from Tracker, enriches skills and occupations, computes rankings, trends, regional projections and optional sectoral intelligence.
+`POST /projector/analyze-skills` fetches jobs from Tracker, enriches skill labels, computes rankings, trends, regional projections and optional sectoral intelligence.
 
 Common fields:
 - `keywords`: optional list of search keywords
@@ -112,10 +112,10 @@ Common fields:
 - `include_sectoral`: enables sectoral intelligence
 
 Sectoral fields:
-- `sector_system`: `isco`, `nace`, or `both`
-- `sector_level`: `isco_group`, `nace_section`, `nace_division`, `nace_group`, `nace_class`, or technical compatibility value `nace_code`
-- `skill_group_level`: ESCO skill group level used for group aggregation
-- `occupation_level`: ESCO occupation level used for official matrix lookup
+- `sector_system`: accepted for compatibility; current runtime uses `nace`
+- `sector_level`: accepted for compatibility; current runtime uses Tracker sector labels
+- `skill_group_level`: accepted for compatibility
+- `occupation_level`: accepted for compatibility
 
 Example:
 
@@ -127,26 +127,27 @@ curl -X POST "http://127.0.0.1:8000/projector/analyze-skills" \
   -d "min_date=2024-01-01" \
   -d "max_date=2024-12-31" \
   -d "include_sectoral=true" \
-  -d "sector_system=both" \
-  -d "sector_level=nace_section"
+  -d "sector_system=nace"
 ```
 
-## Sector Systems
+## Sector Intelligence
 
-The service supports two sector interpretation systems.
+Sector intelligence is API-only and observed-only.
 
-- ISCO: occupation-based. The path is `job -> occupation -> isco_group -> ISCO label`.
-- NACE: economic-activity-based. The path is `job -> occupation -> ESCO-NACE crosswalk -> NACE code/title`.
+Current path:
+
+```text
+Tracker job["sectors"] x Tracker job["skills"]
+```
 
 When sectoral intelligence is enabled, the service builds:
-- `insights.sectoral`: backward-compatible selected/default sectoral payload
-- `insights.sectoral_mode`: requested mode
-- `insights.sectoral_views`: dual ISCO and NACE payloads
-- `insights.sector_view_names`: display names for observed, canonical and matrix views
+- `insights.sectoral`: observed sector-skill payload
+- `insights.sectoral_mode`: `nace`
+- `insights.sectoral_views.nace`: dashboard wrapper with `sector_level=tracker_sector`
 
-NACE is relation-oriented in this implementation. One ESCO occupation may map to multiple NACE codes, so the same job-derived skill evidence may appear in multiple NACE sectors. This is intentional for skill-sector discovery and should not be read as strict one-to-one job accounting.
+Sectors are Tracker labels, not derived NACE hierarchy levels. Sector totals are relationship counts: one job with multiple sectors contributes to each listed sector.
 
-For the detailed ISCO/NACE view definitions, including Observed, Canonical, Official Matrix, Derived Canonical and Aggregated Official Matrix semantics, see [Sector intelligence](docs/sector-intelligence.md).
+See [Sector intelligence](docs/sector-intelligence.md) and [Statistics](docs/statistic.md).
 
 ## Documentation
 
@@ -156,6 +157,7 @@ Start here:
 - [Endpoint cheatsheet](docs/endpoint-cheatsheet.md)
 - [API reference](docs/api-reference.md)
 - [Data model](docs/data-model.md)
+- [Statistics](docs/statistic.md)
 - [Architecture](docs/architecture.md)
 - [Examples](docs/examples.md)
 - [Sector intelligence](docs/sector-intelligence.md)

--- a/app/api/routes/projector.py
+++ b/app/api/routes/projector.py
@@ -8,6 +8,11 @@ from app.core.container import service
 router = APIRouter(prefix="/projector", tags=["Projector"])
 
 
+@router.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
 @router.post("/emerging-skills", response_model=EmergingSkillsResponse)
 async def emerging_skills(min_date: str = Form(...), max_date: str = Form(...),
                           keywords: Optional[List[str]] = Form(None)):
@@ -39,7 +44,7 @@ async def emerging_skills(min_date: str = Form(...), max_date: str = Form(...),
                                  keywords)
 
 
-@router.post("/analyze-skills", response_model=ProjectorResponse)
+@router.post("/analyze-skills", response_model=ProjectorResponse, response_model_exclude_none=True)
 async def analyze_skills(
         keywords: Optional[List[str]] = Form(None),
         locations: Optional[List[str]] = Form(None),
@@ -69,10 +74,8 @@ async def analyze_skills(
            max_date (str, optional): End date (YYYY-MM-DD).
            location_code (str, optional): Geographic filter (ISO/NUTS).
            occupation_ids (List[str], optional): Sector filter (ESCO).
-           sector_system (str, optional): Sector taxonomy system. Supported values:
-               `isco`, `nace`, `both`.
-           sector_level (str, optional): Sector taxonomy level. Supported values:
-               `isco_group`, `nace_section`, `nace_division`, `nace_group`, `nace_class` (plus `nace_code` for technical compatibility).
+           sector_system (str, optional): Compatibility field. Runtime uses Tracker sectors under `nace`.
+           sector_level (str, optional): Compatibility field. Runtime uses Tracker sector labels.
 
        Returns:
            ProjectorResponse:

--- a/app/client/tracker_client.py
+++ b/app/client/tracker_client.py
@@ -220,7 +220,12 @@ class TrackerClient:
 
         if os.path.exists(cache_file):
             logger.info(f"Cache Hit: {query_sig}")
-            with open(cache_file, 'r') as f: return json.load(f)
+            with open(cache_file, 'r') as f:
+                cached_jobs = json.load(f)
+            if cached_jobs and not any("sectors" in job for job in cached_jobs):
+                logger.info(f"Cache stale without job sectors, refetching: {query_sig}")
+            else:
+                return cached_jobs
 
         if not self.engine.token: await self._get_token()
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -6,3 +6,9 @@ load_dotenv()
 TRACKER_API = os.getenv("TRACKER_API")
 TRACKER_USERNAME = os.getenv("TRACKER_USERNAME")
 TRACKER_PASSWORD = os.getenv("TRACKER_PASSWORD")
+USE_LOCAL_SECTOR_FILES = os.getenv("SKILLAB_USE_LOCAL_SECTOR_FILES", "false").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}

--- a/app/core/container.py
+++ b/app/core/container.py
@@ -10,11 +10,7 @@ from app.services.projector_service import ProjectorService
 
 engine = ProjectorEngine()
 tracker = TrackerClient(engine)
-
-
 loader = EscoLoader(engine)
-loader.load_local_esco_support()
-loader.load_official_esco_matrix()
 
 occupations = OccupationAnalytics(engine)
 regional = RegionalAnalytics(engine)

--- a/app/example_dashboard/demo_dashboard.py
+++ b/app/example_dashboard/demo_dashboard.py
@@ -3,6 +3,8 @@ import requests
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
+import os
+import json
 from requests import RequestException
 
 # 1. Configurazione Pagina
@@ -16,11 +18,7 @@ if 'all_data' not in st.session_state:
     st.session_state.all_data = None
 
 if 'api_base_url' not in st.session_state:
-    st.session_state.api_base_url = "http://127.0.0.1:8000/projector"
-
-if 'backend_timeout' not in st.session_state:
-    st.session_state.backend_timeout = 30
-
+    st.session_state.api_base_url = os.getenv("PROJECTOR_API_BASE_URL", "http://127.0.0.1:8000/projector")
 
 def change_lang():
     if st.session_state.lang_choice == "Italiano":
@@ -41,9 +39,13 @@ translations = {
         'stop': "STOP ANALISI ⛔",
         'stop_toast': "Segnale di stop inviato!",
         'server_error': "Server non raggiungibile.",
+        'server_timeout': "Il server ha impiegato troppo tempo a rispondere.",
+        'server_http_error': "Il server ha risposto con errore.",
+        'server_ok': "Backend raggiungibile.",
         'backend_url': "Backend URL",
-        'backend_help': "Avvia FastAPI prima della dashboard. Esempio: `uvicorn app.main:app --reload`",
+        'backend_help': "Avvia FastAPI prima della dashboard. Esempio: `uvicorn app.main:app --reload`. Se Streamlit gira in container o su altra macchina, usa l'URL raggiungibile da Streamlit, non per forza 127.0.0.1.",
         'backend_timeout': "Timeout richiesta backend (secondi)",
+        'check_backend': "Verifica backend",
         'tabs': ["📊 Analisi Competenze", "📈 Emerging Trends", "🗺️ Distribuzione Geografica", "🏭 Settori & Aziende"],
         'top_skills': "Top Skills più richieste",
         'jobs_analyzed': "Job Analizzati",
@@ -69,20 +71,35 @@ translations = {
         'sectoral_header': "🧠 Sectoral Intelligence",
         'sector_selector': "Seleziona settore",
         'observed_skills': "Observed Skills",
-        'canonical_skills': "Canonical Skills",
         'observed_groups': "Observed Skill Groups",
-        'canonical_groups': "Canonical Skill Groups",
-        'official_matrix_groups': "Official ESCO Matrix Groups",
         'no_sectoral': "Dati di Sectoral Intelligence non disponibili.",
         'total_mentions': "Total mentions",
         'unique_items': "Unique items",
-        'sector_mode': "Vista segmentazione",
-        'sector_mode_isco': "ISCO (occupation-based)",
-        'sector_mode_nace': "NACE (economic activity-based)",
-        'sector_compare': "Confronto ISCO vs NACE",
-        'nace_level': "Livello NACE",
-        'agg_level': "Livello di aggregazione",
+        'agg_level': "Fonte settori",
         'categories_found': "Categorie trovate",
+        'loading': "Intelligence in caricamento...",
+        'demo_settings': "Impostazioni demo",
+        'demo_mode': "Abilita dati NUTS demo",
+        'demo_mode_help': "Attiva l'iniezione di codici NUTS fittizi per testare la gerarchia del Task 3.5",
+        'regional_task_header': "🌍 Intelligence regionale e proiezioni NUTS (Task 3.5)",
+        'regional_strategy': "Seleziona granularità della proiezione:",
+        'regional_strategy_help': "Scegli il livello di scomposizione dei dati come richiesto dal Task 3.5",
+        'regional_options': ["Location Codes (Raw)", "NUTS 1 (Macro)", "NUTS 2 (Regioni)", "NUTS 3 (Province)"],
+        'regional_select_area': "Seleziona area per analisi granulare",
+        'market_share': "Quota di mercato",
+        'key_skills_in': "Competenze chiave in",
+        'workforce_profile': "Profilo della forza lavoro",
+        'skill_label': "Competenza",
+        'job_post_label': "Job Post",
+        'specialization_label': "Specializzazione (LQ)",
+        'regional_insight': "L'area **{target_code}** mostra una domanda focalizzata. Le barre più verdi indicano competenze con alta specializzazione regionale.",
+        'regional_no_level': "Dati non disponibili per il livello {strategy}.",
+        'regional_run_first': "Esegui una proiezione per visualizzare l'analisi regionale.",
+        'observed_skills_per_sector': "Skill osservate per settore",
+        'sector_metrics': "Metriche settore",
+        'skill_transversality': "Transversalità skill (NACE)",
+        'skill_coverage_unique': "Copertura skill (uniche)",
+        'top10_skill_dominance': "Dominanza top-10 skill",
     },
     'EN': {
         'title': "🚀 SKILLAB Projector: Intelligence Dashboard",
@@ -95,9 +112,13 @@ translations = {
         'stop': "STOP ANALYSIS ⛔",
         'stop_toast': "Stop signal sent!",
         'server_error': "Server unreachable.",
+        'server_timeout': "Server took too long to respond.",
+        'server_http_error': "Server returned an error.",
+        'server_ok': "Backend reachable.",
         'backend_url': "Backend URL",
-        'backend_help': "Start FastAPI before the dashboard. Example: `uvicorn app.main:app --reload`",
+        'backend_help': "Start FastAPI before the dashboard. Example: `uvicorn app.main:app --reload`. If Streamlit runs in a container or another machine, use the URL reachable from Streamlit, not necessarily 127.0.0.1.",
         'backend_timeout': "Backend request timeout (seconds)",
+        'check_backend': "Check backend",
         'tabs': ["📊 Skill Analysis", "📈 Emerging Trends", "🗺️ Geographic Distribution", "🏭 Sectors & Employers"],
         'top_skills': "Top Requested Skills",
         'jobs_analyzed': "Jobs Analyzed",
@@ -123,43 +144,193 @@ translations = {
         'sectoral_header': "🧠 Sectoral Intelligence",
         'sector_selector': "Select sector",
         'observed_skills': "Observed Skills",
-        'canonical_skills': "Canonical Skills",
         'observed_groups': "Observed Skill Groups",
-        'canonical_groups': "Canonical Skill Groups",
-        'official_matrix_groups': "Official ESCO Matrix Groups",
         'no_sectoral': "Sectoral Intelligence data not available.",
         'total_mentions': "Total mentions",
         'unique_items': "Unique items",
-        'sector_mode': "Segmentation view",
-        'sector_mode_isco': "ISCO (occupation-based)",
-        'sector_mode_nace': "NACE (economic activity-based)",
-        'sector_compare': "ISCO vs NACE comparison",
-        'nace_level': "NACE level",
-        'agg_level': "Aggregation level",
+        'agg_level': "Sector source",
         'categories_found': "Categories found",
+        'loading': "Intelligence is loading...",
+        'demo_settings': "Demo Settings",
+        'demo_mode': "Enable NUTS Demo Data",
+        'demo_mode_help': "Injects synthetic NUTS codes to test Task 3.5 hierarchy.",
+        'regional_task_header': "🌍 Regional Intelligence & NUTS Projections (Task 3.5)",
+        'regional_strategy': "Select projection granularity:",
+        'regional_strategy_help': "Choose the data decomposition level required by Task 3.5.",
+        'regional_options': ["Location Codes (Raw)", "NUTS 1 (Macro)", "NUTS 2 (Regions)", "NUTS 3 (Provinces)"],
+        'regional_select_area': "Select area for granular analysis",
+        'market_share': "Market Share",
+        'key_skills_in': "Key skills in",
+        'workforce_profile': "Workforce profile",
+        'skill_label': "Skill",
+        'job_post_label': "Job posts",
+        'specialization_label': "Specialization (LQ)",
+        'regional_insight': "Area **{target_code}** shows focused demand. Greener bars indicate skills with high regional specialization.",
+        'regional_no_level': "Data not available for level {strategy}.",
+        'regional_run_first': "Run a projection to view regional analysis.",
+        'observed_skills_per_sector': "Observed Skills per Sector",
+        'sector_metrics': "Sector Metrics",
+        'skill_transversality': "Skill Transversality (NACE)",
+        'skill_coverage_unique': "Skill coverage (unique)",
+        'top10_skill_dominance': "Top-10 skill dominance",
     }
 }
 
 T = translations[st.session_state.lang]
 
+DEV_TEXT = {
+    "IT": {
+        "endpoint": "Endpoint",
+        "example_request": "Esempio richiesta",
+        "example_answer": "Esempio risposta",
+        "data_used": "Dati usati qui",
+    },
+    "EN": {
+        "endpoint": "Endpoint",
+        "example_request": "Example request",
+        "example_answer": "Example answer",
+        "data_used": "Data used here",
+    }
+}
+
+DEV_LABELS = {
+    "IT": {
+        "Backend connection": "Connessione backend",
+        "Stop request": "Richiesta stop",
+        "Skill ranking": "Ranking skill",
+        "Trend view": "Vista trend",
+        "Geographic summary": "Sintesi geografica",
+        "Regional intelligence": "Intelligence regionale",
+        "Sectors, titles, employers": "Settori, titoli, aziende",
+        "Sector distribution chart": "Grafico distribuzione settori",
+        "Job titles": "Titoli lavoro",
+        "Employers": "Aziende",
+        "Sectoral intelligence": "Intelligence settoriale",
+        "Observed skills in selected sector": "Skill osservate nel settore selezionato",
+        "Sector metrics": "Metriche settore",
+        "Skill transversality": "Transversalità skill",
+    },
+    "EN": {}
+}
+
+STAT_HELP_BY_LANG = {
+    "IT": {
+        "jobs_analyzed": "Numero di job Tracker processati dopo i filtri. Formula: count(jobs).",
+        "skill_frequency": "Numero di occorrenze della skill nei job analizzati. Una skill è contata una volta per job che la contiene.",
+        "volume_growth": "Variazione volume job tra seconda metà e prima metà del periodo. Formula: (jobs_B - jobs_A) / jobs_A * 100.",
+        "skill_growth": "Variazione percentuale della skill tra seconda metà e prima metà del periodo. Se prima metà = 0 e seconda > 0: new_entry.",
+        "geo_job_count": "Numero di job per location_code. Formula: count(jobs where job.location_code = area).",
+        "market_share": "Quota dell'area sul totale job analizzati. Formula: jobs_area / all_jobs * 100.",
+        "regional_skill_count": "Numero di job nell'area che contengono quella skill.",
+        "specialization": "Concentrazione relativa della skill nell'area. Formula: (skill_area/jobs_area) / (skill_global/all_jobs). Sopra 1 = sopra media.",
+        "sector_mentions": "Totale menzioni skill nel settore. Formula: sum(sector_skill_count[sector].values()).",
+        "title_count": "Numero di job con questo titolo. Formula: count(jobs where title = value).",
+        "employer_count": "Numero di job pubblicati da questa azienda. Formula: count(jobs where organization = value).",
+        "total_skill_mentions": "Totale menzioni skill nel settore selezionato. Formula: sum(count skill nel settore).",
+        "unique_skills": "Numero di skill distinte nel settore selezionato. Formula: count(distinct skills in sector).",
+        "observed_skill_count": "Numero di volte in cui la skill appare nel settore selezionato.",
+        "observed_skill_frequency": "Peso della skill nel settore. Formula: skill_count_in_sector / total_skill_mentions_in_sector.",
+        "coverage_unique_skills": "Copertura skill del settore. Formula: count(distinct skills in sector).",
+        "dominance_top10_share": "Concentrazione delle top 10 skill. Formula: sum(top_10_skill_counts) / total_skill_mentions_in_sector.",
+        "importance_in_sector": "Importanza della skill nel settore selezionato. Formula: skill_count_in_sector / total_skill_mentions_in_sector.",
+        "sector_breadth": "Transversalità della skill. Formula: count(sectors where skill appears).",
+        "dominant_share": "Quota della skill nel suo settore dominante. Formula: count_in_dominant_sector / count_in_all_sectors.",
+        "categories_found": "Numero di settori Tracker API trovati nella risposta sectoral. Formula: count(insights.sectoral_views.nace.items).",
+    },
+    "EN": {
+        "jobs_analyzed": "Number of Tracker jobs processed after filters. Formula: count(jobs).",
+        "skill_frequency": "Number of skill occurrences in analyzed jobs. A skill is counted once per job that contains it.",
+        "volume_growth": "Job volume change between second half and first half of the period. Formula: (jobs_B - jobs_A) / jobs_A * 100.",
+        "skill_growth": "Skill percentage change between second half and first half of the period. If first half = 0 and second half > 0: new_entry.",
+        "geo_job_count": "Number of jobs by location_code. Formula: count(jobs where job.location_code = area).",
+        "market_share": "Area share of all analyzed jobs. Formula: jobs_area / all_jobs * 100.",
+        "regional_skill_count": "Number of jobs in the area that contain that skill.",
+        "specialization": "Relative concentration of the skill in the area. Formula: (skill_area/jobs_area) / (skill_global/all_jobs). Above 1 = above average.",
+        "sector_mentions": "Total skill mentions in the sector. Formula: sum(sector_skill_count[sector].values()).",
+        "title_count": "Number of jobs with this title. Formula: count(jobs where title = value).",
+        "employer_count": "Number of jobs posted by this employer. Formula: count(jobs where organization = value).",
+        "total_skill_mentions": "Total skill mentions in the selected sector. Formula: sum(skill counts in sector).",
+        "unique_skills": "Number of distinct skills in the selected sector. Formula: count(distinct skills in sector).",
+        "observed_skill_count": "Number of times the skill appears in the selected sector.",
+        "observed_skill_frequency": "Skill weight inside the sector. Formula: skill_count_in_sector / total_skill_mentions_in_sector.",
+        "coverage_unique_skills": "Sector skill coverage. Formula: count(distinct skills in sector).",
+        "dominance_top10_share": "Top-10 skill concentration. Formula: sum(top_10_skill_counts) / total_skill_mentions_in_sector.",
+        "importance_in_sector": "Skill importance in selected sector. Formula: skill_count_in_sector / total_skill_mentions_in_sector.",
+        "sector_breadth": "Skill transversality. Formula: count(sectors where skill appears).",
+        "dominant_share": "Skill share in its dominant sector. Formula: count_in_dominant_sector / count_in_all_sectors.",
+        "categories_found": "Number of Tracker API sectors found in sectoral response. Formula: count(insights.sectoral_views.nace.items).",
+    }
+}
+
+STAT_HELP = STAT_HELP_BY_LANG[st.session_state.lang]
+
 st.title(T['title'])
 st.markdown(T['subtitle'])
 
-@st.cache_data(ttl=600)
+def normalize_api_base_url(api_base_url: str) -> str:
+    return str(api_base_url or "").strip().rstrip("/")
+
+
+def check_backend(api_base_url: str, timeout_seconds: int):
+    try:
+        res = requests.get(
+            f"{normalize_api_base_url(api_base_url)}/health",
+            timeout=min(int(timeout_seconds), 10)
+        )
+    except requests.Timeout as exc:
+        return {"_error": f"{T['server_timeout']} ({exc})"}
+    except RequestException as exc:
+        return {"_error": f"{T['server_error']} ({exc})"}
+
+    if res.status_code == 200:
+        return {"status": "ok"}
+
+    return {"_error": f"{T['server_http_error']} [HTTP {res.status_code}] {res.text[:300]}"}
+
+
 def get_analysis_data(api_base_url: str, payload: dict, timeout_seconds: int):
     try:
         res = requests.post(
-            f"{api_base_url}/analyze-skills",
+            f"{normalize_api_base_url(api_base_url)}/analyze-skills",
             data=payload,
             timeout=timeout_seconds
         )
+    except requests.Timeout as exc:
+        return {"_error": f"{T['server_timeout']} ({exc})"}
     except RequestException as exc:
         return {"_error": f"{T['server_error']} ({exc})"}
 
     if res.status_code == 200:
         return res.json()
 
-    return {"_error": f"{T['server_error']} [HTTP {res.status_code}]"}
+    return {"_error": f"{T['server_http_error']} [HTTP {res.status_code}] {res.text[:500]}"}
+
+
+def dev_info(label: str, endpoint: str, response_example: dict, used_fields: list[str], payload_example: dict | None = None):
+    with st.popover("API", use_container_width=False):
+        dev_text = DEV_TEXT[st.session_state.lang]
+        translated_label = DEV_LABELS[st.session_state.lang].get(label, label)
+        st.markdown(f"**{translated_label}**")
+        st.markdown(dev_text["endpoint"])
+        st.code(endpoint, language="http")
+        if payload_example:
+            st.markdown(dev_text["example_request"])
+            st.code(json.dumps(payload_example, indent=2), language="json")
+        st.markdown(dev_text["example_answer"])
+        st.code(json.dumps(response_example, indent=2), language="json")
+        st.markdown(dev_text["data_used"])
+        for field in used_fields:
+            st.markdown(f"- `{field}`")
+
+
+def metric_with_info(label: str, value, info: str, **kwargs):
+    st.metric(label, value, help=info, **kwargs)
+
+
+ANALYZE_ENDPOINT = "POST /projector/analyze-skills"
+EMERGING_ENDPOINT = "POST /projector/emerging-skills"
+HEALTH_ENDPOINT = "GET /projector/health"
+STOP_ENDPOINT = "POST /projector/stop"
 
 
 with st.sidebar:
@@ -177,21 +348,42 @@ with st.sidebar:
 
     st.markdown("---")
     st.text_input(T["backend_url"], key="api_base_url")
+    dev_info(
+        "Backend connection",
+        HEALTH_ENDPOINT,
+        {"status": "ok"},
+        ["status"]
+    )
+    timeout_kwargs = {}
+    if "backend_timeout" not in st.session_state:
+        timeout_kwargs["value"] = 600
     st.number_input(
         T["backend_timeout"],
         min_value=5,
-        max_value=120,
-        value=30,
-        step=5,
-        key="backend_timeout"
+        max_value=1800,
+        step=60,
+        key="backend_timeout",
+        **timeout_kwargs
     )
+    if st.button(T["check_backend"], use_container_width=True):
+        health = check_backend(st.session_state.api_base_url, st.session_state.backend_timeout)
+        if health.get("status") == "ok":
+            st.success(T["server_ok"])
+        else:
+            st.error(health.get("_error", T["server_error"]))
     st.caption(T["backend_help"])
     st.markdown("---")
 
+    dev_info(
+        "Stop request",
+        STOP_ENDPOINT,
+        {"status": "signal_sent"},
+        ["status"]
+    )
     if st.button(T['stop'], type="primary", use_container_width=True):
         try:
             requests.post(
-                f"{st.session_state.api_base_url}/stop",
+                f"{normalize_api_base_url(st.session_state.api_base_url)}/stop",
                 timeout=st.session_state.backend_timeout
             )
             st.toast(T['stop_toast'])
@@ -199,9 +391,8 @@ with st.sidebar:
             st.error(f"{T['server_error']} ({exc})")
 
     st.markdown("---")
-    st.subheader("🛠️ Demo Settings")
-    demo_mode = st.checkbox("Enable NUTS Demo Data", value=False,
-                            help="Attiva l'iniezione di codici NUTS fittizi per testare la gerarchia del Task 3.5")
+    st.subheader(f"🛠️ {T['demo_settings']}")
+    demo_mode = st.checkbox(T["demo_mode"], value=False, help=T["demo_mode_help"])
 
 # Costruzione Payload
 payload = {
@@ -211,15 +402,14 @@ payload = {
     "max_date": date_range[1].strftime("%Y-%m-%d"),
     "demo": demo_mode,
     "include_sectoral": True,
-    "sector_system": "both",
-    "sector_level": "nace_section",
+    "sector_system": "nace",
     "skill_group_level": 1,
     "occupation_level": 1
 }
 
 # --- LOGICA DI ACQUISIZIONE DATI ---
 if submit_button:
-    with st.spinner("🚀 Intelligence is loading..."):
+    with st.spinner(f"🚀 {T['loading']}"):
         data = get_analysis_data(
             st.session_state.api_base_url,
             payload,
@@ -242,7 +432,39 @@ if st.session_state.all_data:
 
     # --- TAB 1: RANKING SKILLS ---
     with tab1:
-        st.header(T['top_skills'])
+        h_main, h_info = st.columns([8, 1])
+        with h_main:
+            st.header(T['top_skills'], help=STAT_HELP["skill_frequency"])
+        with h_info:
+            dev_info(
+                "Skill ranking",
+                ANALYZE_ENDPOINT,
+                {
+                    "insights": {
+                        "ranking": [
+                            {
+                                "name": "Python",
+                                "frequency": 120,
+                                "primary_sector": "Information and communication",
+                                "sector_spread": 4,
+                                "is_green": False,
+                                "is_digital": False
+                            }
+                        ]
+                    },
+                    "dimension_summary": {"jobs_analyzed": 1250}
+                },
+                [
+                    "insights.ranking[].name",
+                    "insights.ranking[].frequency",
+                    "insights.ranking[].primary_sector",
+                    "insights.ranking[].sector_spread",
+                    "insights.ranking[].is_green",
+                    "insights.ranking[].is_digital",
+                    "dimension_summary.jobs_analyzed"
+                ],
+                payload
+            )
         ranking = ins.get("ranking", [])
         if ranking:
             df_ranking = pd.DataFrame(ranking).head(15)
@@ -261,13 +483,56 @@ if st.session_state.all_data:
                 fig.update_layout(yaxis={'categoryorder': 'total ascending'})
                 st.plotly_chart(fig, use_container_width=True)
             with col2:
-                st.metric(T['jobs_analyzed'], summary.get("jobs_analyzed", 0))
-                st.subheader(T['intelligence_label'])
-                st.dataframe(df_ranking[['name', 'frequency', 'primary_sector', 'Twin']], use_container_width=True)
+                metric_with_info(T['jobs_analyzed'], summary.get("jobs_analyzed", 0), STAT_HELP["jobs_analyzed"])
+                st.subheader(T['intelligence_label'], help=STAT_HELP["skill_frequency"])
+                st.dataframe(
+                    df_ranking[['name', 'frequency', 'primary_sector', 'Twin']],
+                    use_container_width=True,
+                    column_config={
+                        "frequency": st.column_config.NumberColumn(
+                            "frequency (i)",
+                            help=STAT_HELP["skill_frequency"]
+                        )
+                    }
+                )
 
     # --- TAB 2: TRENDS ---
     with tab2:
-        st.header(T['trends_header'])
+        h_main, h_info = st.columns([8, 1])
+        with h_main:
+            st.header(T['trends_header'], help=f"{STAT_HELP['volume_growth']} {STAT_HELP['skill_growth']}")
+        with h_info:
+            dev_info(
+                "Trend view",
+                ANALYZE_ENDPOINT,
+                {
+                    "insights": {
+                        "trends": {
+                            "market_health": {
+                                "status": "expanding",
+                                "volume_growth_percentage": 12.5
+                            },
+                            "trends": [
+                                {
+                                    "name": "Python",
+                                    "growth": 20.0,
+                                    "trend_type": "emerging",
+                                    "primary_sector": "Information and communication"
+                                }
+                            ]
+                        }
+                    }
+                },
+                [
+                    "insights.trends.market_health.status",
+                    "insights.trends.market_health.volume_growth_percentage",
+                    "insights.trends.trends[].name",
+                    "insights.trends.trends[].growth",
+                    "insights.trends.trends[].trend_type",
+                    "insights.trends.trends[].primary_sector"
+                ],
+                payload
+            )
         trend_data = ins.get("trends", {})
 
         if trend_data:
@@ -298,7 +563,26 @@ if st.session_state.all_data:
 
     # --- TAB 3: GEOGRAFIA ---
     with tab3:
-        st.header(T['geo_header'])
+        h_main, h_info = st.columns([8, 1])
+        with h_main:
+            st.header(T['geo_header'], help=STAT_HELP["geo_job_count"])
+        with h_info:
+            dev_info(
+                "Geographic summary",
+                ANALYZE_ENDPOINT,
+                {
+                    "dimension_summary": {
+                        "geo_breakdown": [
+                            {"location": "IT", "job_count": 820}
+                        ]
+                    }
+                },
+                [
+                    "dimension_summary.geo_breakdown[].location",
+                    "dimension_summary.geo_breakdown[].job_count"
+                ],
+                payload
+            )
         geo = summary.get("geo_breakdown", [])
 
         # --- PARTE A: Mappa Globale ---
@@ -324,20 +608,65 @@ if st.session_state.all_data:
 
         if regional_dict:
             st.markdown("---")
-            st.header("🌍 Regional Intelligence & NUTS Projections (Task 3.5)")
+            h_main, h_info = st.columns([8, 1])
+            with h_main:
+                st.header(
+                    T["regional_task_header"],
+                    help=f"{STAT_HELP['market_share']} {STAT_HELP['specialization']}"
+                )
+            with h_info:
+                dev_info(
+                    "Regional intelligence",
+                    ANALYZE_ENDPOINT,
+                    {
+                        "insights": {
+                            "regional": {
+                                "raw": [
+                                    {
+                                        "code": "IT",
+                                        "total_jobs": 120,
+                                        "market_share": 9.6,
+                                        "top_skills": [
+                                            {
+                                                "skill": "Python",
+                                                "count": 33,
+                                                "specialization": 1.78
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "nuts1": [],
+                                "nuts2": [],
+                                "nuts3": []
+                            }
+                        }
+                    },
+                    [
+                        "insights.regional.raw[]",
+                        "insights.regional.nuts1[]",
+                        "insights.regional.nuts2[]",
+                        "insights.regional.nuts3[]",
+                        "regional item.code",
+                        "regional item.market_share",
+                        "regional item.top_skills[].skill",
+                        "regional item.top_skills[].count",
+                        "regional item.top_skills[].specialization"
+                    ],
+                    payload
+                )
 
             strategy = st.radio(
-                "Seleziona granularità della proiezione:",
-                ["Location Codes (Raw)", "NUTS 1 (Macro)", "NUTS 2 (Regioni)", "NUTS 3 (Province)"],
+                T["regional_strategy"],
+                T["regional_options"],
                 horizontal=True,
-                help="Scegli il livello di scomposizione dei dati come richiesto dal Task 3.5"
+                help=T["regional_strategy_help"]
             )
 
             strat_map = {
-                "Location Codes (Raw)": "raw",
-                "NUTS 1 (Macro)": "nuts1",
-                "NUTS 2 (Regioni)": "nuts2",
-                "NUTS 3 (Province)": "nuts3"
+                T["regional_options"][0]: "raw",
+                T["regional_options"][1]: "nuts1",
+                T["regional_options"][2]: "nuts2",
+                T["regional_options"][3]: "nuts3"
             }
 
             selected_list = regional_dict.get(strat_map[strategy], [])
@@ -348,17 +677,19 @@ if st.session_state.all_data:
 
                 with col_sel:
                     target_code = st.selectbox(
-                        f"Seleziona area per analisi granulare ({strategy}):",
+                        f"{T['regional_select_area']} ({strategy}):",
                         area_codes
                     )
 
                 target = next(i for i in selected_list if i["code"] == target_code)
 
                 with col_met:
-                    st.metric("Market Share", f"{target['market_share']}%",
-                              help="Incidenza dell'area sul volume totale")
+                    metric_with_info(T["market_share"], f"{target['market_share']}%", STAT_HELP["market_share"])
 
-                st.subheader(f"Competenze chiave in {target_code}")
+                st.subheader(
+                    f"{T['key_skills_in']} {target_code}",
+                    help=f"{STAT_HELP['regional_skill_count']} {STAT_HELP['specialization']}"
+                )
                 df_reg_skills = pd.DataFrame(target["top_skills"])
 
                 fig_reg = px.bar(
@@ -369,63 +700,103 @@ if st.session_state.all_data:
                     text="count",
                     color="specialization",
                     color_continuous_scale="RdYlGn",
-                    labels={"skill": "Competenza", "count": "Job Post", "specialization": "Specializzazione (LQ)"},
-                    title=f"Profilo della forza lavoro: {target_code}"
+                    labels={
+                        "skill": T["skill_label"],
+                        "count": T["job_post_label"],
+                        "specialization": T["specialization_label"]
+                    },
+                    title=f"{T['workforce_profile']}: {target_code}"
                 )
                 fig_reg.update_layout(yaxis={'categoryorder': 'total ascending'}, height=400)
                 st.plotly_chart(fig_reg, use_container_width=True)
 
-                st.info(f"💡 **Insight Task 3.5**: L'area **{target_code}** mostra una domanda focalizzata. Le barre più verdi indicano competenze con alta specializzazione regionale.")
+                st.info(f"💡 **Insight Task 3.5**: {T['regional_insight'].format(target_code=target_code)}")
             else:
-                st.warning(f"Dati non disponibili per il livello {strategy}.")
+                st.warning(T["regional_no_level"].format(strategy=strategy))
         else:
-            st.info("Esegui una proiezione per visualizzare l'analisi regionale.")
+            st.info(T["regional_run_first"])
 
     # --- TAB 4: SETTORI, JOBS & EMPLOYERS ---
     with tab4:
-        st.header(T['jobs_emp_header'])
+        h_main, h_info = st.columns([8, 1])
+        with h_main:
+            st.header(
+                T['jobs_emp_header'],
+                help=f"{STAT_HELP['sector_mentions']} {STAT_HELP['title_count']} {STAT_HELP['employer_count']}"
+            )
+        with h_info:
+            dev_info(
+                "Sectors, titles, employers",
+                ANALYZE_ENDPOINT,
+                {
+                    "insights": {
+                        "sectors": [{"name": "Education", "count": 42}],
+                        "job_titles": [{"name": "Logistics Coordinator", "count": 8}],
+                        "employers": [{"name": "Example Ltd", "count": 5}],
+                        "sectoral_views": {
+                            "nace": {
+                                "sector_level": "tracker_sector",
+                                "items": []
+                            }
+                        }
+                    }
+                },
+                [
+                    "insights.sectors[].name",
+                    "insights.sectors[].count",
+                    "insights.job_titles[].name",
+                    "insights.job_titles[].count",
+                    "insights.employers[].name",
+                    "insights.employers[].count",
+                    "insights.sectoral_views.nace.items[]"
+                ],
+                payload
+            )
 
         sectoral_views = ins.get("sectoral_views") or {}
-        isco_sectoral = (sectoral_views.get("isco") or {}).get("items", [])
         nace_views = (sectoral_views.get("nace") or {})
-        nace_levels = (nace_views.get("levels") or {})
-        default_nace_level = nace_views.get("selected_level", "nace_section")
-        nace_level_options = [
-            ("Section", "nace_section"),
-            ("Division", "nace_division"),
-            ("Group", "nace_group"),
-            ("Class", "nace_class"),
-        ]
-        nace_labels = [x[0] for x in nace_level_options]
-        nace_key_by_label = {label: key for label, key in nace_level_options}
-        nace_label_by_key = {key: label for label, key in nace_level_options}
-        default_nace_label = nace_label_by_key.get(default_nace_level, "Section")
-        default_nace_index = nace_labels.index(default_nace_label)
-
-        selector_col, level_col = st.columns([2, 1])
-        with selector_col:
-            sector_mode_label = st.radio(T["sector_mode"], [T["sector_mode_isco"], T["sector_mode_nace"]], horizontal=True)
-        with level_col:
-            selected_nace_label = st.selectbox(T["nace_level"], nace_labels, index=default_nace_index)
-            selected_nace_level = nace_key_by_label[selected_nace_label]
-
-        nace_sectoral = (nace_levels.get(selected_nace_level) or {}).get("items", [])
-        selected_mode = "isco" if sector_mode_label == T["sector_mode_isco"] else "nace"
-        active_sectoral = isco_sectoral if selected_mode == "isco" else nace_sectoral
+        nace_sectoral = nace_views.get("items", [])
+        active_sectoral = nace_sectoral
         fallback_sectoral = ins.get("sectoral", None)
         if not active_sectoral:
             active_sectoral = fallback_sectoral or []
 
         st.caption(
-            f"Sector system: {'ISCO' if selected_mode == 'isco' else 'NACE'} | "
-            f"{T['agg_level']}: {'ISCO Group' if selected_mode == 'isco' else selected_nace_label} | "
+            f"Sector system: NACE | "
+            f"{T['agg_level']}: Tracker API job sectors | "
             f"{T['categories_found']}: {len(active_sectoral)}"
         )
-
         c1, c2, c3 = st.columns(3)
 
         with c1:
-            st.subheader(T['top_sectors'])
+            st.subheader(T['top_sectors'], help=STAT_HELP["sector_mentions"])
+            dev_info(
+                "Sector distribution chart",
+                ANALYZE_ENDPOINT,
+                {
+                    "insights": {
+                        "sectoral_views": {
+                            "nace": {
+                                "items": [
+                                    {
+                                        "sector": "Education",
+                                        "sector_label": "Education",
+                                        "observed_skills": {
+                                            "total_skill_mentions": 100
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                [
+                    "insights.sectoral_views.nace.items[].sector",
+                    "insights.sectoral_views.nace.items[].sector_label",
+                    "insights.sectoral_views.nace.items[].observed_skills.total_skill_mentions"
+                ],
+                payload
+            )
             if active_sectoral:
                 df_sec = pd.DataFrame([
                     {
@@ -435,12 +806,11 @@ if st.session_state.all_data:
                     for item in active_sectoral
                 ])
                 df_sec = df_sec[df_sec["count"] > 0]
-                chart_level_label = "ISCO Group" if selected_mode == "isco" else f"NACE {selected_nace_label}"
                 fig_sec = px.pie(
                     df_sec,
                     values='count',
                     names='name',
-                    title=f"Demand by {chart_level_label}",
+                    title="Demand by Tracker API sectors",
                     hole=0.4,
                     color_discrete_sequence=px.colors.qualitative.Pastel
                 )
@@ -451,7 +821,23 @@ if st.session_state.all_data:
                 st.write(T['no_data'])
 
         with c2:
-            st.subheader(T['top_titles'])
+            st.subheader(T['top_titles'], help=STAT_HELP["title_count"])
+            dev_info(
+                "Job titles",
+                ANALYZE_ENDPOINT,
+                {
+                    "insights": {
+                        "job_titles": [
+                            {"name": "Software Engineer", "count": 25}
+                        ]
+                    }
+                },
+                [
+                    "insights.job_titles[].name",
+                    "insights.job_titles[].count"
+                ],
+                payload
+            )
             jt = ins.get("job_titles", [])
             if jt:
                 st.plotly_chart(px.bar(pd.DataFrame(jt), x='count', y='name', orientation='h',
@@ -460,7 +846,23 @@ if st.session_state.all_data:
                 st.write(T['no_data'])
 
         with c3:
-            st.subheader(T['top_emp'])
+            st.subheader(T['top_emp'], help=STAT_HELP["employer_count"])
+            dev_info(
+                "Employers",
+                ANALYZE_ENDPOINT,
+                {
+                    "insights": {
+                        "employers": [
+                            {"name": "Example Ltd", "count": 12}
+                        ]
+                    }
+                },
+                [
+                    "insights.employers[].name",
+                    "insights.employers[].count"
+                ],
+                payload
+            )
             emp = ins.get("employers", [])
             if emp:
                 st.plotly_chart(px.pie(pd.DataFrame(emp), values='count', names='name',
@@ -468,16 +870,48 @@ if st.session_state.all_data:
             else:
                 st.write(T['no_data'])
         st.markdown("---")
-        st.header(T['sectoral_header'])
+        h_main, h_info = st.columns([8, 1])
+        with h_main:
+            st.header(
+                T['sectoral_header'],
+                help=f"{STAT_HELP['total_skill_mentions']} {STAT_HELP['importance_in_sector']} {STAT_HELP['sector_breadth']}"
+            )
+        with h_info:
+            dev_info(
+                "Sectoral intelligence",
+                ANALYZE_ENDPOINT,
+                {
+                    "insights": {
+                        "sectoral_views": {
+                            "nace": {
+                                "sector_level": "tracker_sector",
+                                "items": [
+                                    {
+                                        "sector": "Education",
+                                        "sector_label": "Education",
+                                        "observed_skills": {},
+                                        "sector_metrics": {},
+                                        "skill_transversal_insights": []
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                [
+                    "insights.sectoral_views.nace.sector_level",
+                    "insights.sectoral_views.nace.items[].sector",
+                    "insights.sectoral_views.nace.items[].sector_label",
+                    "insights.sectoral_views.nace.items[].observed_skills",
+                    "insights.sectoral_views.nace.items[].sector_metrics",
+                    "insights.sectoral_views.nace.items[].skill_transversal_insights"
+                ],
+                payload
+            )
         sectoral = active_sectoral
 
         if sectoral:
-            observed_title = "Observed"
-            canonical_title = "Canonical" if selected_mode == "isco" else "Derived Canonical"
-            matrix_title = "Official ESCO Matrix Groups" if selected_mode == "isco" else "Aggregated Official Matrix"
-            if selected_mode == "nace":
-                st.caption("In NACE mode, Canonical and Matrix views are derived from ESCO occupation-based relations aggregated through the ESCO-NACE crosswalk.")
-
+            observed_title = T["observed_skills_per_sector"]
             sector_options = {
                 f"{item.get('sector_label', item['sector'])} ({item['sector']})": item["sector"]
                 for item in sectoral
@@ -488,238 +922,213 @@ if st.session_state.all_data:
 
             if target_sector:
                 # =========================
-                # A. OBSERVED vs CANONICAL SKILLS
+                # A. OBSERVED SKILLS
                 # =========================
-                col_obs, col_can = st.columns(2)
-
-                with col_obs:
-                    st.subheader(observed_title)
-                    obs = target_sector.get("observed_skills", {})
-                    st.metric(T['total_mentions'], obs.get("total_skill_mentions", 0))
-                    st.metric(T['unique_items'], obs.get("unique_skills", 0))
-
-                    obs_skills = obs.get("top_skills", [])
-                    if obs_skills:
-                        df_obs = pd.DataFrame(obs_skills)
-                        label_col = "label" if "label" in df_obs.columns else "skill_id"
-
-                        fig_obs = px.bar(
-                            df_obs,
-                            x="count",
-                            y=label_col,
-                            orientation="h",
-                            title=observed_title
-                        )
-                        fig_obs.update_layout(yaxis={'categoryorder': 'total ascending'})
-                        st.plotly_chart(fig_obs, use_container_width=True)
-
-                        display_cols = [c for c in ["skill_id", "label", "count", "frequency", "is_green", "is_digital"] if c in df_obs.columns]
-                        st.dataframe(df_obs[display_cols], use_container_width=True)
-                    else:
-                        st.write(T['no_data'])
-
-                with col_can:
-                    st.subheader(canonical_title)
-                    can = target_sector.get("canonical_skills", {})
-                    st.metric(T['total_mentions'], can.get("total_skill_mentions", 0))
-                    st.metric(T['unique_items'], can.get("unique_skills", 0))
-
-                    can_skills = can.get("top_skills", [])
-                    if can_skills:
-                        df_can = pd.DataFrame(can_skills)
-                        label_col = "label" if "label" in df_can.columns else "skill_id"
-
-                        fig_can = px.bar(
-                            df_can,
-                            x="count",
-                            y=label_col,
-                            orientation="h",
-                            title=canonical_title
-                        )
-                        fig_can.update_layout(yaxis={'categoryorder': 'total ascending'})
-                        st.plotly_chart(fig_can, use_container_width=True)
-
-                        display_cols = [c for c in ["skill_id", "label", "count", "frequency", "is_green", "is_digital"] if c in df_can.columns]
-                        st.dataframe(df_can[display_cols], use_container_width=True)
-                    else:
-                        st.write(T['no_data'])
-
-                # =========================
-                # B. GROUP PROFILES
-                # =========================
-                st.markdown("---")
-                g1, g2, g3 = st.columns(3)
-
-                with g1:
-                    st.subheader(T['observed_groups'])
-                    obs_groups = target_sector.get("observed_groups", {})
-                    st.metric(T['total_mentions'], obs_groups.get("total_group_mentions", 0))
-                    st.metric(T['unique_items'], obs_groups.get("unique_groups", 0))
-
-                    top_groups = obs_groups.get("top_groups", [])
-                    if top_groups:
-                        df_og = pd.DataFrame(top_groups)
-                        fig_og = px.bar(
-                            df_og,
-                            x="count",
-                            y="group_label" if "group_label" in df_og.columns else "group_id",                            orientation="h",
-                            title=T['observed_groups']
-                        )
-                        fig_og.update_layout(yaxis={'categoryorder': 'total ascending'})
-                        st.plotly_chart(fig_og, use_container_width=True)
-                        st.dataframe(df_og, use_container_width=True)
-                    else:
-                        st.write(T['no_data'])
-
-                # with g2:
-                #     st.subheader(T['canonical_groups'])
-                #     can_groups = target_sector.get("canonical_groups", {})
-                #     st.metric(T['total_mentions'], can_groups.get("total_group_mentions", 0))
-                #     st.metric(T['unique_items'], can_groups.get("unique_groups", 0))
-                #
-                #     top_groups = can_groups.get("top_groups", [])
-                #     if top_groups:
-                #         df_cg = pd.DataFrame(top_groups)
-                #         fig_cg = px.bar(
-                #             df_cg,
-                #             x="count",
-                #             y="group_label" if "group_label" in df_og.columns else "group_id",                            orientation="h",
-                #             title=T['canonical_groups']
-                #         )
-                #         fig_cg.update_layout(yaxis={'categoryorder': 'total ascending'})
-                #         st.plotly_chart(fig_cg, use_container_width=True)
-                #         st.dataframe(df_cg, use_container_width=True)
-                #     else:
-                #         st.write(T['no_data'])
-
-                # with g2:
-                #     st.subheader(T['canonical_groups'])
-                #     can_groups = target_sector.get("canonical_groups", {})
-                #     st.metric(T['total_mentions'], can_groups.get("total_group_mentions", 0))
-                #     st.metric(T['unique_items'], can_groups.get("unique_groups", 0))
-                #
-                #     top_groups = can_groups.get("top_groups", [])
-                #     if top_groups:
-                #         df_cg = pd.DataFrame(top_groups)
-                #         fig_cg = px.bar(
-                #             df_cg,
-                #             x="count",
-                #             y="group_label" if "group_label" in df_og.columns else "group_id", orientation="h",
-                #             title=T['canonical_groups']
-                #         )
-                #         fig_cg.update_layout(yaxis={'categoryorder': 'total ascending'})
-                #         st.plotly_chart(fig_cg, use_container_width=True)
-                #         st.dataframe(df_cg, use_container_width=True)
-                #     else:
-                #         st.write(T['no_data'])
-
-                with g2:
-                    st.subheader(T['canonical_groups'])
-                    can_groups = target_sector.get("canonical_groups", {})
-                    st.metric(T['total_mentions'], can_groups.get("total_group_mentions", 0))
-                    st.metric(T['unique_items'], can_groups.get("unique_groups", 0))
-
-                    top_groups = can_groups.get("top_groups", [])
-                    if top_groups:
-                        df_cg = pd.DataFrame(top_groups)
-                        fig_cg = px.bar(
-                            df_cg,
-                            x="count",
-                            y="group_label" if "group_label" in df_cg.columns else "group_id",
-                            orientation="h",
-                            title=T['canonical_groups']
-                        )
-                        fig_cg.update_layout(yaxis={'categoryorder': 'total ascending'})
-                        st.plotly_chart(fig_cg, use_container_width=True)
-                        st.dataframe(df_cg, use_container_width=True)
-                    else:
-                        st.write(T['no_data'])
-
-                with g3:
-                    st.subheader(matrix_title)
-                    off_groups = target_sector.get("matrix_groups", {})
-                    st.metric(T['total_mentions'], off_groups.get("total_group_mentions", 0))
-                    st.metric(T['unique_items'], off_groups.get("unique_groups", 0))
-
-                    top_groups = off_groups.get("top_groups", [])
-                    if top_groups:
-                        df_fg = pd.DataFrame(top_groups)
-                        fig_fg = px.bar(
-                            df_fg,
-                            x="count",
-                            y="group_label" if "group_label" in df_fg.columns else "group_id",
-                            orientation="h",
-                            title=matrix_title
-                        )
-                        fig_fg.update_layout(yaxis={'categoryorder': 'total ascending'})
-                        st.plotly_chart(fig_fg, use_container_width=True)
-                        st.dataframe(df_fg, use_container_width=True)
-                    else:
-                        st.write(T['no_data'])
-
-                st.markdown("---")
-                st.subheader(T["sector_compare"])
-                c_left, c_right = st.columns(2)
-                with c_left:
-                    st.caption(f"ISCO categories: {len(isco_sectoral)}")
-                    isco_mentions = sum(x.get("observed_skills", {}).get("total_skill_mentions", 0) for x in isco_sectoral)
-                    st.metric("ISCO total mentions", isco_mentions)
-                    if isco_sectoral:
-                        df_isco = pd.DataFrame([
-                            {
-                                "sector": x.get("sector"),
-                                "sector_label": x.get("sector_label"),
-                                "mentions": x.get("observed_skills", {}).get("total_skill_mentions", 0),
+                h_main, h_info = st.columns([8, 1])
+                with h_main:
+                    st.subheader(
+                        observed_title,
+                        help=f"{STAT_HELP['total_skill_mentions']} {STAT_HELP['unique_skills']} {STAT_HELP['observed_skill_frequency']}"
+                    )
+                with h_info:
+                    dev_info(
+                        "Observed skills in selected sector",
+                        ANALYZE_ENDPOINT,
+                        {
+                            "observed_skills": {
+                                "sector": "Education",
+                                "total_skill_mentions": 100,
+                                "unique_skills": 25,
+                                "top_skills": [
+                                    {
+                                        "skill_id": "http://data.europa.eu/esco/skill/...",
+                                        "label": "Python",
+                                        "count": 10,
+                                        "frequency": 0.1,
+                                        "is_green": False,
+                                        "is_digital": False
+                                    }
+                                ]
                             }
-                            for x in isco_sectoral
-                        ])
-                        st.dataframe(df_isco.sort_values("mentions", ascending=False).head(10), use_container_width=True)
-                with c_right:
-                    st.caption(f"NACE categories ({selected_nace_label}): {len(nace_sectoral)}")
-                    nace_mentions = sum(x.get("observed_skills", {}).get("total_skill_mentions", 0) for x in nace_sectoral)
-                    st.metric("NACE total mentions", nace_mentions)
-                    if nace_sectoral:
-                        df_nace = pd.DataFrame([
-                            {
-                                "sector": x.get("sector"),
-                                "sector_label": x.get("sector_label"),
-                                "mentions": x.get("observed_skills", {}).get("total_skill_mentions", 0),
-                            }
-                            for x in nace_sectoral
-                        ])
-                        st.dataframe(df_nace.sort_values("mentions", ascending=False).head(10), use_container_width=True)
+                        },
+                        [
+                            "selected sector.observed_skills.total_skill_mentions",
+                            "selected sector.observed_skills.unique_skills",
+                            "selected sector.observed_skills.top_skills[].skill_id",
+                            "selected sector.observed_skills.top_skills[].label",
+                            "selected sector.observed_skills.top_skills[].count",
+                            "selected sector.observed_skills.top_skills[].frequency"
+                        ],
+                        payload
+                    )
+                obs = target_sector.get("observed_skills", {})
+                m1, m2 = st.columns(2)
+                with m1:
+                    metric_with_info(T['total_mentions'], obs.get("total_skill_mentions", 0), STAT_HELP["total_skill_mentions"])
+                with m2:
+                    metric_with_info(T['unique_items'], obs.get("unique_skills", 0), STAT_HELP["unique_skills"])
 
+                obs_skills = obs.get("top_skills", [])
+                if obs_skills:
+                    df_obs = pd.DataFrame(obs_skills)
+                    label_col = "label" if "label" in df_obs.columns else "skill_id"
+
+                    fig_obs = px.bar(
+                        df_obs,
+                        x="count",
+                        y=label_col,
+                        orientation="h",
+                        title=observed_title,
+                        labels={label_col: "skill"}
+                    )
+
+                    fig_obs.update_layout(yaxis={'categoryorder': 'total ascending'})
+                    st.plotly_chart(fig_obs, use_container_width=True)
+
+                    display_cols = [c for c in ["skill_id", "label", "count", "frequency", "is_green", "is_digital"] if c in df_obs.columns]
+                    st.dataframe(
+                        df_obs[display_cols],
+                        use_container_width=True,
+                        column_config={
+                            "count": st.column_config.NumberColumn(
+                                "count (i)",
+                                help=STAT_HELP["observed_skill_count"]
+                            ),
+                            "frequency": st.column_config.NumberColumn(
+                                "frequency (i)",
+                                help=STAT_HELP["observed_skill_frequency"]
+                            )
+                        }
+                    )
+                else:
+                    st.write(T['no_data'])
+
+                # =========================
+                # B. OBSERVED GROUP PROFILE
+                # =========================
+                # st.markdown("---")
+                # st.subheader(T['observed_groups'])
+                # obs_groups = target_sector.get("observed_groups", {})
+                # gm1, gm2 = st.columns(2)
+                # with gm1:
+                #     st.metric(T['total_mentions'], obs_groups.get("total_group_mentions", 0))
+                # with gm2:
+                #     st.metric(T['unique_items'], obs_groups.get("unique_groups", 0))
+                #
+                # top_groups = obs_groups.get("top_groups", [])
+                # if top_groups:
+                #     df_og = pd.DataFrame(top_groups)
+                #     fig_og = px.bar(
+                #         df_og,
+                #         x="count",
+                #         y="group_label" if "group_label" in df_og.columns else "group_id",
+                #         orientation="h",
+                #         title=T['observed_groups']
+                #     )
+                #     fig_og.update_layout(yaxis={'categoryorder': 'total ascending'})
+                #     st.plotly_chart(fig_og, use_container_width=True)
+                #     st.dataframe(df_og, use_container_width=True)
+                # else:
+                #     st.write(T['no_data'])
+                #
                 st.markdown("---")
-                st.subheader("Sector Metrics")
+                h_main, h_info = st.columns([8, 1])
+                with h_main:
+                    st.subheader(
+                        T["sector_metrics"],
+                        help=f"{STAT_HELP['coverage_unique_skills']} {STAT_HELP['dominance_top10_share']}"
+                    )
+                with h_info:
+                    dev_info(
+                        "Sector metrics",
+                        ANALYZE_ENDPOINT,
+                        {
+                            "sector_metrics": {
+                                "coverage_unique_skills": 25,
+                                "dominance_top10_share": 0.62
+                            }
+                        },
+                        [
+                            "selected sector.sector_metrics.coverage_unique_skills",
+                            "selected sector.sector_metrics.dominance_top10_share"
+                        ],
+                        payload
+                    )
                 sec_metrics = target_sector.get("sector_metrics", {})
                 sm1, sm2 = st.columns(2)
                 with sm1:
-                    st.metric("Skill coverage (unique)", sec_metrics.get("coverage_unique_skills", 0))
+                    metric_with_info(
+                        T["skill_coverage_unique"],
+                        sec_metrics.get("coverage_unique_skills", 0),
+                        STAT_HELP["coverage_unique_skills"]
+                    )
                 with sm2:
-                    st.metric("Top-10 skill dominance", sec_metrics.get("dominance_top10_share", 0.0))
+                    metric_with_info(
+                        T["top10_skill_dominance"],
+                        sec_metrics.get("dominance_top10_share", 0.0),
+                        STAT_HELP["dominance_top10_share"]
+                    )
 
-                if selected_mode == "nace":
-                    st.subheader("Skill Transversality (NACE)")
-                    insights = target_sector.get("skill_transversal_insights", [])
-                    if insights:
-                        df_ins = pd.DataFrame(insights)
-                        cols = [c for c in ["label", "count", "importance_in_sector", "sector_breadth", "dominant_sector_label", "dominant_share"] if c in df_ins.columns]
-                        st.dataframe(df_ins[cols], use_container_width=True)
-                    else:
-                        st.write(T['no_data'])
-
-                if selected_mode == "isco":
-                    st.subheader("ISCO Interpretation")
-                    interp = target_sector.get("isco_interpretation") or {}
-                    it1, it2, it3 = st.columns(3)
-                    with it1:
-                        st.metric("Stability overlap", interp.get("stability_overlap", 0.0))
-                    with it2:
-                        st.metric("Emerging skills", len(interp.get("emerging_skills", [])))
-                    with it3:
-                        st.metric("Missing skills", len(interp.get("missing_skills", [])))
-                    st.caption(f"Emerging: {', '.join(interp.get('emerging_skills', [])[:10])}" if interp.get("emerging_skills") else "Emerging: none")
-                    st.caption(f"Missing: {', '.join(interp.get('missing_skills', [])[:10])}" if interp.get("missing_skills") else "Missing: none")
+                h_main, h_info = st.columns([8, 1])
+                with h_main:
+                    st.subheader(
+                        T["skill_transversality"],
+                        help=f"{STAT_HELP['importance_in_sector']} {STAT_HELP['sector_breadth']} {STAT_HELP['dominant_share']}"
+                    )
+                with h_info:
+                    dev_info(
+                        "Skill transversality",
+                        ANALYZE_ENDPOINT,
+                        {
+                            "skill_transversal_insights": [
+                                {
+                                    "label": "Python",
+                                    "count": 10,
+                                    "importance_in_sector": 0.1,
+                                    "sector_breadth": 4,
+                                    "dominant_sector_label": "Information and communication",
+                                    "dominant_share": 0.52
+                                }
+                            ]
+                        },
+                        [
+                            "selected sector.skill_transversal_insights[].label",
+                            "selected sector.skill_transversal_insights[].count",
+                            "selected sector.skill_transversal_insights[].importance_in_sector",
+                            "selected sector.skill_transversal_insights[].sector_breadth",
+                            "selected sector.skill_transversal_insights[].dominant_sector_label",
+                            "selected sector.skill_transversal_insights[].dominant_share"
+                        ],
+                        payload
+                    )
+                insights = target_sector.get("skill_transversal_insights", [])
+                if insights:
+                    df_ins = pd.DataFrame(insights)
+                    cols = [c for c in ["label", "count", "importance_in_sector", "sector_breadth", "dominant_sector_label", "dominant_share"] if c in df_ins.columns]
+                    st.dataframe(
+                        df_ins[cols],
+                        use_container_width=True,
+                        column_config={
+                            "count": st.column_config.NumberColumn(
+                                "count (i)",
+                                help=STAT_HELP["observed_skill_count"]
+                            ),
+                            "importance_in_sector": st.column_config.NumberColumn(
+                                "importance_in_sector (i)",
+                                help=STAT_HELP["importance_in_sector"]
+                            ),
+                            "sector_breadth": st.column_config.NumberColumn(
+                                "sector_breadth (i)",
+                                help=STAT_HELP["sector_breadth"]
+                            ),
+                            "dominant_share": st.column_config.NumberColumn(
+                                "dominant_share (i)",
+                                help=STAT_HELP["dominant_share"]
+                            )
+                        }
+                    )
+                else:
+                    st.write(T['no_data'])
         else:
             st.info(T['no_sectoral'])
 

--- a/app/schemas/responses.py
+++ b/app/schemas/responses.py
@@ -153,10 +153,10 @@ class SectoralSectorItem(BaseModel):
     sector: str
     sector_label: str
     observed_skills: SectorSkillSummary
-    canonical_skills: SectorSkillSummary
     observed_groups: SectorGroupSummary
-    canonical_groups: SectorGroupSummary
-    matrix_groups: SectorGroupSummary
+    canonical_skills: Optional[SectorSkillSummary] = None
+    canonical_groups: Optional[SectorGroupSummary] = None
+    matrix_groups: Optional[SectorGroupSummary] = None
     sector_metrics: Optional[SectorMetrics] = None
     skill_transversal_insights: Optional[List[SkillTransversalInsight]] = None
     isco_interpretation: Optional[IscoInterpretation] = None
@@ -184,19 +184,19 @@ class ProjectorInsights(BaseModel):
     )
     sectoral: Optional[List[SectoralSectorItem]] = Field(
         default=None,
-        description="Sectoral intelligence combining observed, canonical, and official ESCO matrix profiles"
+        description="Observed sectoral intelligence from Tracker job skills and sectors"
     )
     sectoral_mode: Optional[Literal["isco", "nace", "both"]] = Field(
         default=None,
-        description="Selected sector segmentation mode for the response payload."
+        description="Compatibility field. Current runtime returns 'nace' for Tracker sector views."
     )
     sectoral_views: Optional[dict[Literal["isco", "nace"], SectoralView | NaceSectoralViews]] = Field(
         default=None,
-        description="Dual sectoral payloads for ISCO and NACE segmentation modes. NACE includes all hierarchy levels."
+        description="Sectoral payloads. Current runtime exposes the NACE key with Tracker sector labels."
     )
     sector_view_names: Optional[dict[str, dict[str, str]]] = Field(
         default=None,
-        description="Display names for sectoral views by system (e.g. NACE uses derived naming)."
+        description="Display names for observed sectoral views."
     )
 
 

--- a/app/services/analytics/market.py
+++ b/app/services/analytics/market.py
@@ -93,11 +93,12 @@ class MarketAnalytics:
             if self.engine.stop_requested: break
             if i > 0 and i % 2000 == 0: await asyncio.sleep(0)
 
-            # 1. Occupation -> sector
-            occ_ids = self.occupations.get_occupation_ids(job)
+            # 1. Use Tracker job sectors only.
+            job_sector_names = self.occupations.get_sector_keys_from_job(job, level="nace_section")
 
-            for occ_id in occ_ids:
-                sector_name = self.occupations.get_sector_from_occupation(occ_id, level="isco_group")
+            sector_names = job_sector_names or ["Sector not specified"]
+
+            for sector_name in sector_names:
                 sec_cnt[sector_name] += 1
 
             for s_uri in job.get("skills", []):
@@ -106,8 +107,7 @@ class MarketAnalytics:
                 if s_uri not in skill_sector_map:
                     skill_sector_map[s_uri] = Counter()
 
-                for occ_id in occ_ids:
-                    sector_name = self.occupations.get_sector_from_occupation(occ_id, level="isco_group")
+                for sector_name in sector_names:
                     skill_sector_map[s_uri][sector_name] += 1
 
             e_cnt[job.get("organization_name") or "N/D"] += 1

--- a/app/services/analytics/occupations.py
+++ b/app/services/analytics/occupations.py
@@ -209,6 +209,121 @@ class OccupationAnalytics:
         sector = self.get_sector_from_occupation(occ_id, level=level)
         return [sector] if sector else []
 
+    def get_sector_keys_from_job(self, job: dict, level: str = "nace_section") -> List[str]:
+        if not str(level).startswith("nace"):
+            return []
+        return [m["code"] for m in self.get_nace_mappings_from_job(job, level=level)]
+
+    def get_nace_mappings_from_job(self, job: dict, level: str = "nace_section") -> List[dict]:
+        """
+        Read NACE sectors directly from Tracker job payloads.
+
+        Tracker versions may expose sectors as strings, dicts, or nested objects.
+        Accept common code keys defensively and normalize to the requested NACE
+        level so sectoral analytics do not depend on occupation -> NACE crosswalks.
+        """
+        if not isinstance(job, dict):
+            return []
+
+        dedup = {}
+        for raw_sector in self._iter_job_sector_entries(job.get("sectors")):
+            code, label = self._extract_sector_code_and_label(raw_sector)
+            base_code = self.normalize_nace_code(code)
+            label = str(label or "").strip()
+            if not base_code and not label:
+                label = str(code or "").strip()
+            if not base_code and label:
+                base_code = label
+            if not base_code:
+                continue
+
+            final_code = base_code if level == "nace_code" else self._get_nace_level_code(base_code, level)
+            if not final_code and label:
+                final_code = label
+            if not final_code:
+                continue
+
+            if label:
+                self.engine.nace_labels.setdefault(final_code, label)
+
+            final_label = self.engine.nace_labels.get(final_code)
+            if not final_label and len(final_code) == 1 and final_code.isalpha():
+                final_label = NACE_SECTION_LABELS.get(final_code)
+            if not final_label:
+                final_label = label if final_code == base_code and label else final_code
+
+            dedup.setdefault(final_code, {"code": final_code, "label": final_label})
+
+        return [dedup[k] for k in sorted(dedup.keys())]
+
+    def _iter_job_sector_entries(self, raw_sectors):
+        if not raw_sectors:
+            return []
+        if isinstance(raw_sectors, list):
+            return raw_sectors
+        if isinstance(raw_sectors, tuple):
+            return list(raw_sectors)
+        if isinstance(raw_sectors, dict):
+            for key in ("items", "results", "data", "sectors"):
+                nested = raw_sectors.get(key)
+                if isinstance(nested, list):
+                    return nested
+            return [raw_sectors]
+        return [raw_sectors]
+
+    def _extract_sector_code_and_label(self, raw_sector) -> tuple[str, str]:
+        if isinstance(raw_sector, str):
+            return raw_sector, ""
+
+        if not isinstance(raw_sector, dict):
+            return str(raw_sector or ""), ""
+
+        for nested_key in ("nace", "sector", "classification"):
+            nested = raw_sector.get(nested_key)
+            if isinstance(nested, dict):
+                code, label = self._extract_sector_code_and_label(nested)
+                if code:
+                    return code, label
+
+        code_keys = (
+            "code",
+            "id",
+            "uri",
+            "nace_code",
+            "naceCode",
+            "sector_code",
+            "sectorCode",
+            "external_id",
+            "externalId",
+            "conceptUri",
+        )
+        label_keys = (
+            "label",
+            "name",
+            "title",
+            "preferredLabel",
+            "nace_label",
+            "naceLabel",
+            "sector_label",
+            "sectorLabel",
+        )
+
+        code = ""
+        for key in code_keys:
+            value = raw_sector.get(key)
+            if value:
+                code = str(value).strip()
+                break
+
+        label = ""
+        for key in label_keys:
+            value = raw_sector.get(key)
+            if value:
+                label = str(value).strip()
+                break
+
+        return code, label
+
     def normalize_nace_code(self, nace_code: str) -> str:
         """
         Normalize NACE codes to standard display format.
@@ -334,7 +449,7 @@ class OccupationAnalytics:
         if str(system or "isco").strip().lower() == "nace":
             nace_code = self.normalize_nace_code(sector_code)
             if not nace_code:
-                return "Sector not specified"
+                return sector_code
             if len(nace_code) == 1 and nace_code.isalpha():
                 return NACE_SECTION_LABELS.get(nace_code, nace_code)
             return self.engine.nace_labels.get(nace_code, nace_code)

--- a/app/services/analytics/sectoral.py
+++ b/app/services/analytics/sectoral.py
@@ -7,6 +7,17 @@ class SectoralAnalytics:
         self.engine = engine
         self.occupations = occupations
 
+    def _get_sector_keys_for_job_occupation(self, job: dict, occ_id: str, sector_level: str):
+        if str(sector_level).startswith("nace"):
+            job_sectors = self.occupations.get_sector_keys_from_job(job, level=sector_level)
+            if job_sectors:
+                return job_sectors
+        return self.occupations.get_sector_keys_from_occupation(occ_id, level=sector_level)
+
+    def _get_nace_sector_keys_for_job(self, job: dict, sector_level: str):
+        sector_names = self.occupations.get_sector_keys_from_job(job, level=sector_level)
+        return sector_names or ["Sector not specified"]
+
 
 
     def build_observed_occupation_skill_matrix(self, jobs: List[dict], reset: bool = True):
@@ -94,7 +105,7 @@ class SectoralAnalytics:
                 continue
 
             for occ_id in occ_ids:
-                sector_names = self.occupations.get_sector_keys_from_occupation(occ_id, level=sector_level)
+                sector_names = self._get_sector_keys_for_job_occupation(job, occ_id, sector_level)
                 canonical_skills = self.engine.occ_skill_relations.get(occ_id, set())
                 for sector_name in sector_names:
                     for skill_id in canonical_skills:
@@ -243,12 +254,22 @@ class SectoralAnalytics:
             self.engine.sector_skill_observed = defaultdict(Counter)
 
         for job in jobs:
+            if str(sector_level).startswith("nace"):
+                sector_names = self._get_nace_sector_keys_for_job(job, sector_level)
+                for sector_name in sector_names:
+                    for skill_id in job.get("skills", []):
+                        skill_id = str(skill_id).strip()
+                        if not skill_id:
+                            continue
+                        self.engine.sector_skill_observed[sector_name][skill_id] += 1
+                continue
+
             occ_ids = self.occupations.get_occupation_ids(job)
             if not occ_ids:
                 continue
 
             for occ_id in occ_ids:
-                sector_names = self.occupations.get_sector_keys_from_occupation(occ_id, level=sector_level)
+                sector_names = self._get_sector_keys_for_job_occupation(job, occ_id, sector_level)
                 for sector_name in sector_names:
                     for skill_id in job.get("skills", []):
                         skill_id = str(skill_id).strip()
@@ -717,7 +738,7 @@ class SectoralAnalytics:
                 if not group_code:
                     continue
 
-                sector_names = self.occupations.get_sector_keys_from_occupation(occ_id, level=sector_level)
+                sector_names = self._get_sector_keys_for_job_occupation(job, occ_id, sector_level)
 
                 official = self.occupations.get_official_esco_profile_for_occupation(
                     occ_id=occ_id,
@@ -813,12 +834,6 @@ class SectoralAnalytics:
             reset=reset
         )
 
-        self.build_canonical_sector_skill_matrix(
-            jobs=jobs,
-            sector_level=sector_level,
-            reset=reset
-        )
-
         self.build_observed_sector_skillgroup_matrix(
             jobs=jobs,
             sector_level=sector_level,
@@ -826,20 +841,10 @@ class SectoralAnalytics:
             reset=reset
         )
 
-        self.build_canonical_sector_skillgroup_matrix(
-            jobs=jobs,
-            sector_level=sector_level,
-            skill_group_level=skill_group_level,
-            reset=reset
-        )
-
-        self.build_official_matrix_sector_skillgroup_profile(
-            jobs=jobs,
-            sector_level=sector_level,
-            skill_group_level=skill_group_level,
-            occupation_level=occupation_level,
-            reset=reset
-        )
+        if reset:
+            self.engine.sector_skill_canonical = defaultdict(Counter)
+            self.engine.sector_skillgroup_canonical = defaultdict(Counter)
+            self.engine.matrix_profiles = defaultdict(Counter)
 
         # 2. Collect all sector names seen in any layer
         sectors = set()
@@ -864,26 +869,19 @@ class SectoralAnalytics:
                 top_k=top_k_skills
             )
 
-            canonical_skills = {
-                "sector": sector_name,
-                "top_skills": self.get_canonical_skills_for_sector(
-                    sector_name=sector_name,
-                    resolve_labels=resolve_labels,
-                    top_k=top_k_skills
-                ),
-                "total_skill_mentions": sum(self.engine.sector_skill_canonical.get(sector_name, Counter()).values()),
-                "unique_skills": len(self.engine.sector_skill_canonical.get(sector_name, Counter()))
-            }
-
-            group_profiles = self.compare_all_group_profiles_for_sector(
-                sector_name=sector_name,
-                top_k=top_k_groups
-            )
-
             sector_total_mentions = observed_skills.get("total_skill_mentions", 0)
             sector_metrics = {
                 "coverage_unique_skills": observed_skills.get("unique_skills", 0),
                 "dominance_top10_share": self.compute_sector_skill_dominance(sector_name, top_k=10)
+            }
+            observed_group_base = self._read_group_counter(
+                self.engine.sector_skillgroup_observed.get(sector_name, Counter()),
+                top_k=top_k_groups
+            )
+            observed_groups = {
+                "total_group_mentions": observed_group_base["total_mentions"],
+                "unique_groups": observed_group_base["unique_groups"],
+                "top_groups": observed_group_base["top_groups"]
             }
 
             skill_transversal_insights = []
@@ -917,12 +915,8 @@ class SectoralAnalytics:
                 "sector_label": self.occupations.get_sector_label(sector_name, system=sector_system),
 
                 "observed_skills": observed_skills,
-                "canonical_skills": canonical_skills,
+                "observed_groups": observed_groups,
 
-                "observed_groups": group_profiles["observed_groups"],
-                "canonical_groups": group_profiles["canonical_groups"],
-
-                "matrix_groups": group_profiles["official_matrix_groups"],
                 "sector_metrics": sector_metrics,
                 "skill_transversal_insights": skill_transversal_insights,
                 "isco_interpretation": isco_interpretation
@@ -948,22 +942,6 @@ class SectoralAnalytics:
             sector_name=sector_name,
             resolve_labels=resolve_labels,
             top_k=top_k_skills
-        )
-
-        canonical_skills = {
-            "sector": sector_name,
-            "top_skills": self.get_canonical_skills_for_sector(
-                sector_name=sector_name,
-                resolve_labels=resolve_labels,
-                top_k=top_k_skills
-            ),
-            "total_skill_mentions": sum(self.engine.sector_skill_canonical.get(sector_name, Counter()).values()),
-            "unique_skills": len(self.engine.sector_skill_canonical.get(sector_name, Counter()))
-        }
-
-        group_profiles = self.compare_all_group_profiles_for_sector(
-            sector_name=sector_name,
-            top_k=top_k_groups
         )
 
         sector_system = "nace" if str(sector_level).startswith("nace") else "isco"
@@ -992,17 +970,20 @@ class SectoralAnalytics:
             })
 
         isco_interpretation = self.compute_isco_skill_gap_and_stability(sector_name) if sector_system == "isco" else None
+        observed_group_base = self._read_group_counter(
+            self.engine.sector_skillgroup_observed.get(sector_name, Counter()),
+            top_k=top_k_groups
+        )
         return {
             "sector": sector_name,
             "sector_label": self.occupations.get_sector_label(sector_name, system=sector_system),
 
             "observed_skills": observed_skills,
-            "canonical_skills": canonical_skills,
-
-            "observed_groups": group_profiles["observed_groups"],
-            "canonical_groups": group_profiles["canonical_groups"],
-
-            "matrix_groups": group_profiles["official_matrix_groups"],
+            "observed_groups": {
+                "total_group_mentions": observed_group_base["total_mentions"],
+                "unique_groups": observed_group_base["unique_groups"],
+                "top_groups": observed_group_base["top_groups"]
+            },
             "sector_metrics": {
                 "coverage_unique_skills": observed_skills.get("unique_skills", 0),
                 "dominance_top10_share": self.compute_sector_skill_dominance(sector_name, top_k=10)
@@ -1027,7 +1008,7 @@ class SectoralAnalytics:
                 continue
 
             for occ_id in occ_ids:
-                sector_names = self.occupations.get_sector_keys_from_occupation(occ_id, level=sector_level)
+                sector_names = self._get_sector_keys_for_job_occupation(job, occ_id, sector_level)
                 canonical_skills = self.engine.occ_skill_relations.get(occ_id, set())
                 for sector_name in sector_names:
                     for skill_id in canonical_skills:
@@ -1050,12 +1031,24 @@ class SectoralAnalytics:
             self.engine.sector_skillgroup_observed = defaultdict(Counter)
 
         for job in jobs:
+            if str(sector_level).startswith("nace"):
+                sector_names = self._get_nace_sector_keys_for_job(job, sector_level)
+                for sector_name in sector_names:
+                    for skill_id in job.get("skills", []):
+                        skill_id = str(skill_id).strip()
+                        if not skill_id:
+                            continue
+
+                        skill_group = self.get_skill_group(skill_id, level=skill_group_level)
+                        self.engine.sector_skillgroup_observed[sector_name][skill_group] += 1
+                continue
+
             occ_ids = self.occupations.get_occupation_ids(job)
             if not occ_ids:
                 continue
 
             for occ_id in occ_ids:
-                sector_names = self.occupations.get_sector_keys_from_occupation(occ_id, level=sector_level)
+                sector_names = self._get_sector_keys_for_job_occupation(job, occ_id, sector_level)
                 for sector_name in sector_names:
                     for skill_id in job.get("skills", []):
                         skill_id = str(skill_id).strip()

--- a/app/services/esco_loader.py
+++ b/app/services/esco_loader.py
@@ -173,7 +173,7 @@ class EscoLoader:
 
 
 
-    def load_local_esco_support(self):
+    def load_local_esco_support(self, use_local_sector_files: bool = True):
 
         """
         Load local CSV support files for:
@@ -183,8 +183,11 @@ class EscoLoader:
 
         This step is safe and incremental: if a file is missing, it is skipped.
         """
-        self.load_esco_nace_crosswalk()
-        self.load_nace_labels()
+        if use_local_sector_files:
+            self.load_esco_nace_crosswalk()
+            self.load_nace_labels()
+        else:
+            logger.info("Local ISCO/NACE sector files disabled; Tracker job.sectors will be used for NACE.")
         base_dir = os.getcwd()
 
         occupations_file = os.path.join(base_dir, "complementary_data", "occupations_en.csv")
@@ -193,8 +196,10 @@ class EscoLoader:
         isco_groups_file = os.path.join(base_dir, "complementary_data", "ISCOGroups_en.csv")
         skill_groups_file = os.path.join(base_dir, "complementary_data", "skillGroups_en.csv")
 
-        # 1) Occupation metadata
-        if os.path.exists(occupations_file):
+        # 1) Occupation metadata.
+        # Disabled in app runtime while validating Tracker API job["sectors"] as NACE source.
+        # Restore with SKILLAB_USE_LOCAL_SECTOR_FILES=true.
+        if use_local_sector_files and os.path.exists(occupations_file):
             try:
                 with open(occupations_file, "r", encoding="utf-8-sig") as f:
                     reader = csv.DictReader(f)
@@ -318,8 +323,10 @@ class EscoLoader:
             except Exception as e:
                 logger.warning(f"Could not load occupationSkillRelations_lt.csv: {e}")
 
-        # 4) Optional ISCO group labels
-        if os.path.exists(isco_groups_file):
+        # 5) Optional ISCO group labels.
+        # Disabled in app runtime while validating Tracker API job["sectors"] as NACE source.
+        # Restore with SKILLAB_USE_LOCAL_SECTOR_FILES=true.
+        if use_local_sector_files and os.path.exists(isco_groups_file):
             try:
                 with open(isco_groups_file, "r", encoding="utf-8-sig") as f:
                     reader = csv.DictReader(f)

--- a/app/services/projector_service.py
+++ b/app/services/projector_service.py
@@ -47,24 +47,11 @@ class ProjectorService:
                 "insights": self.market._empty_insights_p1()  # <--- Coerenza qui
             }
 
-        # Traduzione settori (Phase 1)
-        all_occs = []
         all_skills = []
         for j in raw:
-            all_occs.extend(self.occupations.get_occupation_ids(j))
-            all_skills.extend(j.get("skills", []))  # <--- Aggiungiamo questo!
+            all_skills.extend(j.get("skills", []))
 
-        # Add canonical ESCO skills from occupation-skill relations so their labels are resolved too
-        canonical_skill_ids = set()
-        for occ_id in set(all_occs):
-            canonical_skill_ids.update(self.engine.occ_skill_relations.get(occ_id, set()))
-
-        all_skills.extend(list(canonical_skill_ids))
-
-        occ_uris = list(set(all_occs))  # Rimuove i duplicati
-
-        await self.tracker.fetch_occupation_labels(occ_uris)
-        await self.tracker.fetch_skill_names(list(set(all_skills)))  # Traduciamo una sola volta il set complessivo
+        await self.tracker.fetch_skill_names(list(set(all_skills)))
         # Analisi globale
         analysis = await self.market.analyze_market_data(raw)
 
@@ -79,60 +66,33 @@ class ProjectorService:
         sector_view_names = None
         if include_sectoral:
             normalized_system = str(sector_system or "isco").strip().lower()
-            if normalized_system not in {"isco", "nace", "both"}:
-                normalized_system = "isco"
+            if normalized_system != "nace":
+                normalized_system = "nace"
 
-            requested_level = str(sector_level or "").strip().lower()
-            allowed_nace_levels = ("nace_section", "nace_division", "nace_group", "nace_class")
-
-            def build_sectoral_for_level(selected_level: str):
-                return self.sectoral.build_sectoral_intelligence(
-                    jobs=raw,
-                    sector_level=selected_level,
-                    skill_group_level=skill_group_level,
-                    occupation_level=occupation_level,
-                    resolve_labels=True,
-                    top_k_skills=10,
-                    top_k_groups=10,
-                    reset=True
-                )
-
-            isco_data = build_sectoral_for_level("isco_group")
-            nace_level = requested_level if requested_level in allowed_nace_levels else "nace_section"
-            nace_levels = {
-                level_name: build_sectoral_for_level(level_name)
-                for level_name in allowed_nace_levels
-            }
-            nace_data = nace_levels[nace_level]
+            nace_data = self.sectoral.build_sectoral_intelligence(
+                jobs=raw,
+                sector_level="nace_section",
+                skill_group_level=skill_group_level,
+                occupation_level=occupation_level,
+                resolve_labels=True,
+                top_k_skills=10,
+                top_k_groups=10,
+                reset=True
+            )
 
             sectoral_mode = normalized_system
             sectoral_views = {
-                "isco": {"sector_level": "isco_group", "items": isco_data},
                 "nace": {
-                    "selected_level": nace_level,
-                    "levels": {
-                        level_name: {"sector_level": level_name, "items": level_items}
-                        for level_name, level_items in nace_levels.items()
-                    }
+                    "sector_level": "tracker_sector",
+                    "items": nace_data
                 }
             }
 
-            if normalized_system == "nace":
-                sectoral_data = nace_data
-            else:
-                # Backward-compatible default remains ISCO.
-                sectoral_data = isco_data
+            sectoral_data = nace_data
 
             sector_view_names = {
-                "isco": {
-                    "observed": "Observed",
-                    "canonical": "Canonical",
-                    "matrix": "Official Matrix"
-                },
                 "nace": {
-                    "observed": "Observed",
-                    "canonical": "Derived Canonical",
-                    "matrix": "Aggregated Official Matrix"
+                    "observed": "Observed"
                 }
             }
 

--- a/app/test.py
+++ b/app/test.py
@@ -498,11 +498,10 @@ async def test_fetch_skill_names_enriched_logic():
 async def test_calculate_smart_trends_intelligence_overlap():
     """Verifica che il settore primario sia presente nei risultati dei trend."""
     # Mock jobs con settori specifici
-    mock_jobs_a = [{"occupation_id": "occ_1", "skills": ["s1"]}]
-    mock_jobs_b = [{"occupation_id": "occ_1", "skills": ["s1"], "organization_name": "Test"}]
+    mock_jobs_a = [{"occupation_id": "occ_1", "skills": ["s1"], "sectors": ["Automotive"]}]
+    mock_jobs_b = [{"occupation_id": "occ_1", "skills": ["s1"], "sectors": ["Automotive"], "organization_name": "Test"}]
 
     engine.token = "fake"
-    engine.sector_map = {"occ_1": "Automotive"}
     engine.skill_map = {"s1": {"label": "Battery Tech", "is_green": True, "is_digital": False}}
 
     with patch.object(tracker, 'fetch_all_jobs', new_callable=AsyncMock) as mock_fetch:
@@ -2077,16 +2076,10 @@ def test_build_single_sector_intelligence_returns_all_sections():
     }
 
     engine.sector_skill_observed = defaultdict(Counter)
-    engine.sector_skill_canonical = defaultdict(Counter)
     engine.sector_skillgroup_observed = defaultdict(Counter)
-    engine.sector_skillgroup_canonical = defaultdict(Counter)
-    engine.matrix_profiles = defaultdict(Counter)
 
     engine.sector_skill_observed["ICT"]["skill_a"] = 3
-    engine.sector_skill_canonical["ICT"]["skill_b"] = 2
     engine.sector_skillgroup_observed["ICT"]["S5.1"] = 3
-    engine.sector_skillgroup_canonical["ICT"]["S2.4"] = 2
-    engine.matrix_profiles["ICT"]["S1"] = 1.5
 
     result = sectoral.build_single_sector_intelligence(
         sector_name="ICT",
@@ -2097,16 +2090,16 @@ def test_build_single_sector_intelligence_returns_all_sections():
 
     assert result["sector"] == "ICT"
     assert "observed_skills" in result
-    assert "canonical_skills" in result
     assert "observed_groups" in result
-    assert "canonical_groups" in result
-    assert "matrix_groups" in result
+    assert "sector_metrics" in result
+    assert "skill_transversal_insights" in result
+    assert "canonical_skills" not in result
+    assert "canonical_groups" not in result
+    assert "matrix_groups" not in result
 
     assert result["observed_skills"]["top_skills"][0]["skill_id"] == "skill_a"
-    assert result["canonical_skills"]["top_skills"][0]["skill_id"] == "skill_b"
     assert result["observed_groups"]["top_groups"][0]["group_id"] == "S5.1"
-    assert result["canonical_groups"]["top_groups"][0]["group_id"] == "S2.4"
-    assert result["matrix_groups"]["top_groups"][0]["group_id"] == "S1"
+    assert result["sector_metrics"]["coverage_unique_skills"] == 1
 
 
 def test_build_sectoral_intelligence_from_jobs_builds_all_layers():
@@ -2116,46 +2109,24 @@ def test_build_sectoral_intelligence_from_jobs_builds_all_layers():
     occupations = OccupationAnalytics(engine)
     sectoral = SectoralAnalytics(engine, occupations)
 
-    engine.occupation_meta = {
-        "occ_1": {"label": "Software developer", "isco_group": "C2", "nace_code": "J62"},
-    }
-    engine.occupation_group_labels = {
-        "C2": "C2"
-    }
-
-    engine.occ_skill_relations = defaultdict(set)
-    engine.occ_skill_relations["occ_1"] = {"skill_a", "skill_b"}
-
     engine.skill_map = {
         "skill_a": {"label": "Python", "is_green": False, "is_digital": True},
-        "skill_b": {"label": "SQL", "is_green": False, "is_digital": True},
         "skill_obs": {"label": "Docker", "is_green": False, "is_digital": True},
     }
 
     engine.skill_hierarchy = {
         "skill_a": {"level_1": "S1", "level_2": "S1.1", "level_3": "S1.1.1"},
-        "skill_b": {"level_1": "S2", "level_2": "S2.2", "level_3": "S2.2.1"},
         "skill_obs": {"level_1": "S3", "level_2": "S3.1", "level_3": "S3.1.1"},
     }
 
-    engine.esco_matrix_profiles = {
-        ("Matrix 1.1", "http://data.europa.eu/esco/isco/C2"): {
-            "occupation_group_label": "Professionals",
-            "profile": {
-                "S1": 0.4,
-                "S2": 0.6
-            }
-        }
-    }
-
     jobs = [
-        {"occupation_id": "occ_1", "skills": ["skill_obs"]},
-        {"occupation_id": "occ_1", "skills": ["skill_obs", "skill_a"]},
+        {"skills": ["skill_obs"], "sectors": ["ICT"]},
+        {"skills": ["skill_obs", "skill_a"], "sectors": ["ICT"]},
     ]
 
     result = sectoral.build_sectoral_intelligence(
         jobs=jobs,
-        sector_level="isco_group",
+        sector_level="nace_section",
         skill_group_level=1,
         occupation_level=1,
         resolve_labels=True,
@@ -2167,19 +2138,17 @@ def test_build_sectoral_intelligence_from_jobs_builds_all_layers():
     assert len(result) == 1
     sector = result[0]
 
-    assert sector["sector"] == "C2"
+    assert sector["sector"] == "ICT"
 
     # observed skills
     assert sector["observed_skills"]["total_skill_mentions"] == 3
     assert sector["observed_skills"]["top_skills"][0]["label"] == "Docker"
 
-    # canonical skills
-    assert sector["canonical_skills"]["unique_skills"] == 2
-
-    # groups
     assert len(sector["observed_groups"]["top_groups"]) > 0
-    assert len(sector["canonical_groups"]["top_groups"]) > 0
-    assert len(sector["matrix_groups"]["top_groups"]) > 0
+    assert "canonical_skills" not in sector
+    assert "canonical_groups" not in sector
+    assert "matrix_groups" not in sector
+    assert "skill_transversal_insights" in sector
 
 # ==========================================
 # 14. MATRIX / SCHEMA CONTRACT / EDGE CASES
@@ -2377,16 +2346,10 @@ def test_build_single_sector_intelligence_contains_sector_label_and_matrix_group
     }
 
     engine.sector_skill_observed = defaultdict(Counter)
-    engine.sector_skill_canonical = defaultdict(Counter)
     engine.sector_skillgroup_observed = defaultdict(Counter)
-    engine.sector_skillgroup_canonical = defaultdict(Counter)
-    engine.matrix_profiles = defaultdict(Counter)
 
     engine.sector_skill_observed["ICT"]["skill_a"] = 3
-    engine.sector_skill_canonical["ICT"]["skill_b"] = 2
     engine.sector_skillgroup_observed["ICT"]["S5.1"] = 3
-    engine.sector_skillgroup_canonical["ICT"]["S2.4"] = 2
-    engine.matrix_profiles["ICT"]["S1"] = 1.5
 
     result = sectoral.build_single_sector_intelligence(
         sector_name="ICT",
@@ -2397,7 +2360,9 @@ def test_build_single_sector_intelligence_contains_sector_label_and_matrix_group
 
     assert result["sector"] == "ICT"
     assert "sector_label" in result
-    assert "matrix_groups" in result
+    assert "matrix_groups" not in result
+    assert "observed_groups" in result
+    assert result["sector_metrics"]["coverage_unique_skills"] == 1
 
 
 @pytest.mark.integration
@@ -2412,16 +2377,16 @@ def test_endpoint_analyze_skills_sectoral_contract_with_matrix_groups():
     }
 
     fake_jobs = [
-        {
-            "occupation_id": "occ_1",
-            "skills": ["skill_obs"],
-            "upload_date": "2024-01-02",
-        },
-        {
-            "occupation_id": "occ_1",
-            "skills": ["skill_obs", "skill_a"],
-            "upload_date": "2024-01-08",
-        },
+            {
+                "skills": ["skill_obs"],
+                "sectors": ["Information Technology"],
+                "upload_date": "2024-01-02",
+            },
+            {
+                "skills": ["skill_obs", "skill_a"],
+                "sectors": ["Information Technology"],
+                "upload_date": "2024-01-08",
+            },
     ]
 
     with patch.object(tracker, "fetch_all_jobs", new_callable=AsyncMock) as m_fetch, \
@@ -2467,10 +2432,13 @@ def test_endpoint_analyze_skills_sectoral_contract_with_matrix_groups():
         assert "sector" in sector
         assert "sector_label" in sector
         assert "observed_skills" in sector
-        assert "canonical_skills" in sector
         assert "observed_groups" in sector
-        assert "canonical_groups" in sector
-        assert "matrix_groups" in sector
+        assert "sector_metrics" in sector
+        assert "skill_transversal_insights" in sector
+        assert "canonical_skills" not in sector
+        assert "canonical_groups" not in sector
+        assert "matrix_groups" not in sector
+        assert sector["sector"] == "Information Technology"
 
 
 @pytest.mark.integration
@@ -2485,11 +2453,11 @@ def test_endpoint_analyze_skills_sectoral_top_groups_include_group_label():
     }
 
     fake_jobs = [
-        {
-            "occupation_id": "occ_1",
-            "skills": ["skill_obs"],
-            "upload_date": "2024-01-02",
-        }
+            {
+                "skills": ["skill_obs"],
+                "sectors": ["Information Technology"],
+                "upload_date": "2024-01-02",
+            }
     ]
 
     with patch.object(tracker, "fetch_all_jobs", new_callable=AsyncMock) as m_fetch, \
@@ -2532,12 +2500,12 @@ def test_endpoint_analyze_skills_sectoral_top_groups_include_group_label():
         sector = data["insights"]["sectoral"][0]
 
         assert "group_label" in sector["observed_groups"]["top_groups"][0]
-        assert "group_label" in sector["canonical_groups"]["top_groups"][0]
-        assert "group_label" in sector["matrix_groups"]["top_groups"][0]
+        assert "canonical_groups" not in sector
+        assert "matrix_groups" not in sector
 
 
 @pytest.mark.integration
-def test_endpoint_analyze_skills_sectoral_supports_nace_hierarchy_selection():
+def test_endpoint_analyze_skills_sectoral_uses_tracker_sector_labels_without_hierarchy():
     form_data = {
         "keywords": ["developer"],
         "min_date": "2024-01-01",
@@ -2551,8 +2519,8 @@ def test_endpoint_analyze_skills_sectoral_supports_nace_hierarchy_selection():
 
     fake_jobs = [
         {
-            "occupation_id": "occ_1",
             "skills": ["skill_obs"],
+            "sectors": ["Professional services"],
             "upload_date": "2024-01-02",
         }
     ]
@@ -2591,7 +2559,9 @@ def test_endpoint_analyze_skills_sectoral_supports_nace_hierarchy_selection():
 
         data = response.json()
         sector = data["insights"]["sectoral"][0]
-        assert sector["sector"] == "10.11"
+        assert sector["sector"] == "Professional services"
+        assert data["insights"]["sectoral_views"]["nace"]["sector_level"] == "tracker_sector"
+        assert "levels" not in data["insights"]["sectoral_views"]["nace"]
         assert sector["sector_metrics"]["coverage_unique_skills"] >= 1
         assert "dominance_top10_share" in sector["sector_metrics"]
         assert len(sector["skill_transversal_insights"]) >= 1
@@ -2654,12 +2624,12 @@ def test_endpoint_analyze_skills_sectoral_prefers_tracker_job_sectors_for_nace()
 
         data = response.json()
         sector = data["insights"]["sectoral"][0]
-        assert sector["sector"] == "70.22"
-        assert sector["sector_label"] == "Business and other management consultancy activities"
+        assert sector["sector"] == "M"
+        assert sector["sector_label"] == "Professional, scientific and technical activities"
         assert data["insights"]["sectors"][0]["name"] == "M"
 
 @pytest.mark.integration
-def test_endpoint_analyze_skills_sectoral_uses_isco_when_sector_system_is_isco():
+def test_endpoint_analyze_skills_sectoral_forces_tracker_sector_view_when_sector_system_is_isco():
     form_data = {
         "keywords": ["developer"],
         "min_date": "2024-01-01",
@@ -2673,8 +2643,8 @@ def test_endpoint_analyze_skills_sectoral_uses_isco_when_sector_system_is_isco()
 
     fake_jobs = [
         {
-            "occupation_id": "occ_1",
             "skills": ["skill_obs"],
+            "sectors": ["Information Technology"],
             "upload_date": "2024-01-02",
         }
     ]
@@ -2713,15 +2683,14 @@ def test_endpoint_analyze_skills_sectoral_uses_isco_when_sector_system_is_isco()
 
         data = response.json()
         sector = data["insights"]["sectoral"][0]
-        assert sector["sector"] == "C2"
-        assert sector["isco_interpretation"] is not None
-        assert "emerging_skills" in sector["isco_interpretation"]
-        assert "missing_skills" in sector["isco_interpretation"]
-        assert "stability_overlap" in sector["isco_interpretation"]
+        assert data["insights"]["sectoral_mode"] == "nace"
+        assert set(data["insights"]["sectoral_views"].keys()) == {"nace"}
+        assert sector["sector"] == "Information Technology"
+        assert "isco_interpretation" not in sector
 
 
 @pytest.mark.integration
-def test_endpoint_analyze_skills_sectoral_exposes_dual_views_for_comparison():
+def test_endpoint_analyze_skills_sectoral_exposes_tracker_nace_view_only():
     form_data = {
         "keywords": ["developer"],
         "min_date": "2024-01-01",
@@ -2735,8 +2704,8 @@ def test_endpoint_analyze_skills_sectoral_exposes_dual_views_for_comparison():
 
     fake_jobs = [
         {
-            "occupation_id": "occ_1",
             "skills": ["skill_obs"],
+            "sectors": ["Information Technology"],
             "upload_date": "2024-01-02",
         }
     ]
@@ -2774,20 +2743,17 @@ def test_endpoint_analyze_skills_sectoral_exposes_dual_views_for_comparison():
         assert response.status_code == 200
 
         data = response.json()
-        assert data["insights"]["sectoral_mode"] == "both"
-        assert set(data["insights"]["sectoral_views"].keys()) == {"isco", "nace"}
-        assert data["insights"]["sectoral_views"]["isco"]["items"][0]["sector"] == "C2"
-        assert "levels" in data["insights"]["sectoral_views"]["nace"]
-        assert set(data["insights"]["sectoral_views"]["nace"]["levels"].keys()) == {
-            "nace_section", "nace_division", "nace_group", "nace_class"
-        }
-        assert data["insights"]["sectoral_views"]["nace"]["levels"]["nace_class"]["items"][0]["sector"] == "10.11"
+        assert data["insights"]["sectoral_mode"] == "nace"
+        assert set(data["insights"]["sectoral_views"].keys()) == {"nace"}
+        assert data["insights"]["sectoral_views"]["nace"]["sector_level"] == "tracker_sector"
+        assert data["insights"]["sectoral_views"]["nace"]["items"][0]["sector"] == "Information Technology"
+        assert "levels" not in data["insights"]["sectoral_views"]["nace"]
         # Backward compatibility: primary `sectoral` remains list format.
         assert isinstance(data["insights"]["sectoral"], list)
 
 
 @pytest.mark.integration
-def test_endpoint_analyze_skills_sectoral_nace_levels_change_sector_keys():
+def test_endpoint_analyze_skills_sectoral_tracker_labels_define_sector_keys():
     form_data = {
         "keywords": ["developer"],
         "min_date": "2024-01-01",
@@ -2800,8 +2766,8 @@ def test_endpoint_analyze_skills_sectoral_nace_levels_change_sector_keys():
     }
 
     fake_jobs = [
-        {"occupation_id": "occ_1", "skills": ["skill_obs"], "upload_date": "2024-01-02"},
-        {"occupation_id": "occ_2", "skills": ["skill_obs"], "upload_date": "2024-01-03"},
+        {"skills": ["skill_obs"], "sectors": ["Manufacturing"], "upload_date": "2024-01-02"},
+        {"skills": ["skill_obs"], "sectors": ["Information and communication"], "upload_date": "2024-01-03"},
     ]
 
     with patch.object(tracker, "fetch_all_jobs", new_callable=AsyncMock) as m_fetch, \
@@ -2837,14 +2803,13 @@ def test_endpoint_analyze_skills_sectoral_nace_levels_change_sector_keys():
         assert response.status_code == 200
         data = response.json()
 
-        nace_levels = data["insights"]["sectoral_views"]["nace"]["levels"]
-        section_keys = {x["sector"] for x in nace_levels["nace_section"]["items"]}
-        division_keys = {x["sector"] for x in nace_levels["nace_division"]["items"]}
-        class_keys = {x["sector"] for x in nace_levels["nace_class"]["items"]}
-
-        assert section_keys == {"C", "J"}
-        assert division_keys == {"10", "62"}
-        assert class_keys == {"10.11", "62.01"}
+        nace_view = data["insights"]["sectoral_views"]["nace"]
+        assert nace_view["sector_level"] == "tracker_sector"
+        assert "levels" not in nace_view
+        assert {x["sector"] for x in nace_view["items"]} == {
+            "Manufacturing",
+            "Information and communication",
+        }
 
 
 def test_build_observed_occupation_skill_matrix_accumulates_when_reset_false():
@@ -2911,37 +2876,23 @@ def test_build_sectoral_intelligence_and_single_sector_are_consistent():
     occupations = OccupationAnalytics(engine)
     sectoral = SectoralAnalytics(engine, occupations)
 
-    engine.occupation_meta = {
-        "occ_1": {"label": "Software developer", "isco_group": "C2", "nace_code": "J62"},
-    }
-    engine.occupation_group_labels = {"C2": "C2"}
-    engine.occ_skill_relations = defaultdict(set)
-    engine.occ_skill_relations["occ_1"] = {"skill_a", "skill_b"}
     engine.skill_map = {
         "skill_a": {"label": "Python", "is_green": False, "is_digital": True},
-        "skill_b": {"label": "SQL", "is_green": False, "is_digital": True},
         "skill_obs": {"label": "Docker", "is_green": False, "is_digital": True},
     }
     engine.skill_hierarchy = {
         "skill_a": {"level_1": "S1", "level_2": "S1.1", "level_3": "S1.1.1"},
-        "skill_b": {"level_1": "S2", "level_2": "S2.2", "level_3": "S2.2.1"},
         "skill_obs": {"level_1": "S3", "level_2": "S3.1", "level_3": "S3.1.1"},
-    }
-    engine.esco_matrix_profiles = {
-        ("Matrix 1.1", "http://data.europa.eu/esco/isco/C2"): {
-            "occupation_group_label": "Professionals",
-            "profile": {"S1": 0.4, "S2": 0.6}
-        }
     }
 
     jobs = [
-        {"occupation_id": "occ_1", "skills": ["skill_obs"]},
-        {"occupation_id": "occ_1", "skills": ["skill_obs", "skill_a"]},
+        {"skills": ["skill_obs"], "sectors": ["Information Technology"]},
+        {"skills": ["skill_obs", "skill_a"], "sectors": ["Information Technology"]},
     ]
 
     result = sectoral.build_sectoral_intelligence(
         jobs=jobs,
-        sector_level="isco_group",
+        sector_level="nace_section",
         skill_group_level=1,
         occupation_level=1,
         resolve_labels=True,
@@ -2961,5 +2912,7 @@ def test_build_sectoral_intelligence_and_single_sector_are_consistent():
 
     assert single["sector"] == sector["sector"]
     assert single["observed_skills"]["total_skill_mentions"] == sector["observed_skills"]["total_skill_mentions"]
-    assert single["canonical_skills"]["unique_skills"] == sector["canonical_skills"]["unique_skills"]
-    assert single["matrix_groups"]["unique_groups"] == sector["matrix_groups"]["unique_groups"]
+    assert single["observed_groups"]["unique_groups"] == sector["observed_groups"]["unique_groups"]
+    assert single["sector_metrics"] == sector["sector_metrics"]
+    assert "canonical_skills" not in single
+    assert "matrix_groups" not in single

--- a/app/test.py
+++ b/app/test.py
@@ -34,7 +34,7 @@ async def test_engine_analyze_market_data_logic():
     """
     mock_jobs = [
         {"organization_name": "Google", "title": "Dev", "location_code": "IT", "skills": ["s1"],
-         "occupation_id": "occ_1"}
+         "occupation_id": "occ_1", "sectors": ["Tech"]}
     ]
     # Prepariamo le mappe con la nuova struttura
     engine.sector_map = {"occ_1": "Tech"}
@@ -214,11 +214,11 @@ async def test_analyze_market_data_empty_jobs():
 async def test_analyze_market_data_unclassified_sector():
     """Verifica il fallback 'Settore non specificato' se manca occupation_id."""
     mock_jobs = [{"skills": ["s1"]}]  # Manca occupation_id
-    engine.skill_map = {"s1": {"label": "Test", "is_green": False, "is_digital": False}}
+    engine.skill_map = {"s1": {"label": "Test", "is_green": False, "is_digital": False, "sectors": "[]"}}
     engine.sector_map = {}
 
     result = await market.analyze_market_data(mock_jobs)
-    assert result["rankings"]["sectors"] == []
+    assert result["rankings"]["sectors"][0]['name'] == "Sector not specified"
 
 # ==========================================
 # 5. INTEGRATION: ENDPOINT EMERGING SKILLS
@@ -525,9 +525,8 @@ def test_dashboard_phase1_contract():
     form_data = {"keywords": ["data scientist"], "min_date": "2024-01-01", "max_date": "2024-01-02"}
 
     with patch.object(tracker, 'fetch_all_jobs', new_callable=AsyncMock) as m_fetch:
-        # Simulo un job con occupazione e skill
-        m_fetch.return_value = [{"occupation_id": "occ_1", "skills": ["s1"]}]
-        engine.sector_map = {"occ_1": "Information Technology"}
+        # New sector model: sectors arrive directly from the Tracker job payload.
+        m_fetch.return_value = [{"skills": ["s1"], "sectors": ["Information Technology"]}]
         engine.skill_map = {"s1": {"label": "AI", "is_green": False, "is_digital": True}}
 
         response = client.post("/projector/analyze-skills", data=form_data)
@@ -538,6 +537,8 @@ def test_dashboard_phase1_contract():
         assert "is_green" in skill_sample
         assert "is_digital" in skill_sample
         assert "sector_spread" in skill_sample
+        assert skill_sample["sector_spread"] == 1
+        assert skill_sample["primary_sector"] == "Information Technology"
 
         # Verifica dati per Grafico Settori (Nuova Tab 4)
         assert "sectors" in res_data["insights"]

--- a/app/test.py
+++ b/app/test.py
@@ -15,6 +15,7 @@ from app.main import  app
 from app.services.esco_loader import EscoLoader
 from app.services.analytics.occupations import OccupationAnalytics
 from app.services.analytics.sectoral import SectoralAnalytics
+from app.services.projector_service import ProjectorService
 
 from dotenv import load_dotenv
 load_dotenv()
@@ -22,10 +23,189 @@ load_dotenv()
 client = TestClient(app)
 
 
+class _FakeServiceEngine:
+    def __init__(self):
+        self.stop_requested = False
+
+    def request_stop(self):
+        self.stop_requested = True
+
+
+class _FakeServiceTracker:
+    def __init__(self, jobs):
+        self.jobs = jobs
+        self.fetch_payload = None
+        self.skill_names_requested = None
+
+    async def fetch_all_jobs(self, payload):
+        self.fetch_payload = payload
+        return self.jobs
+
+    async def fetch_skill_names(self, skill_ids):
+        self.skill_names_requested = skill_ids
+
+
+class _FakeServiceMarket:
+    def _empty_insights_p1(self):
+        return {"ranking": [], "sectors": [], "job_titles": [], "employers": []}
+
+    async def analyze_market_data(self, jobs):
+        return {
+            "total_jobs": len(jobs),
+            "geo": [{"name": "IT", "count": len(jobs)}],
+            "rankings": {
+                "skills": [
+                    {"id": "skill-python", "name": "Python"},
+                    {"id": "skill-sql", "name": "SQL"},
+                ],
+                "sectors": [{"name": "Education", "count": 1}],
+                "job_titles": [{"name": "Data Scientist", "count": 1}],
+                "employers": [{"name": "ACME", "count": 1}],
+            },
+        }
+
+
+class _FakeServiceTrends:
+    async def calculate_trends_from_data(self, jobs, min_date, max_date):
+        return [{"name": "Python", "growth": 10.0, "window": [min_date, max_date]}]
+
+    async def calculate_smart_trends(self, filters, min_date, max_date):
+        return {"filters": filters, "market_health": {"status": "stable"}, "trends": []}
+
+
+class _FakeServiceRegional:
+    def get_regional_projections(self, jobs, demo=False):
+        return [{"location": "IT", "demo": demo, "count": len(jobs)}]
+
+
+class _FakeServiceSectoral:
+    def __init__(self):
+        self.kwargs = None
+
+    def build_sectoral_intelligence(self, **kwargs):
+        self.kwargs = kwargs
+        return [{"sector": "Education", "observed_skills": [{"skill": "Python"}]}]
+
+
+def _make_projector_service(jobs):
+    fake_engine = _FakeServiceEngine()
+    fake_tracker = _FakeServiceTracker(jobs)
+    fake_sectoral = _FakeServiceSectoral()
+    fake_service = ProjectorService(
+        fake_engine,
+        fake_tracker,
+        occupations=None,
+        regional=_FakeServiceRegional(),
+        market=_FakeServiceMarket(),
+        trends=_FakeServiceTrends(),
+        sectoral=fake_sectoral,
+    )
+    return fake_service, fake_engine, fake_tracker, fake_sectoral
+
+
 
 # ==========================================
 # 1. TEST UNITARI (Engine & Intelligence)
 # ==========================================
+
+@pytest.mark.asyncio
+async def test_projector_service_empty_jobs_returns_empty_insights():
+    fake_service, _, fake_tracker, _ = _make_projector_service([])
+
+    result = await fake_service.analyze_skills(
+        keywords=["data"],
+        locations=["IT"],
+        min_date="2024-01-01",
+        max_date="2024-01-31",
+        page=1,
+        page_size=50,
+        include_sectoral=False,
+    )
+
+    assert result["status"] == "completed"
+    assert result["dimension_summary"]["jobs_analyzed"] == 0
+    assert result["insights"]["ranking"] == []
+    assert fake_tracker.fetch_payload == {
+        "keywords": ["data"],
+        "location_code": ["IT"],
+        "min_upload_date": "2024-01-01",
+        "max_upload_date": "2024-01-31",
+    }
+
+
+@pytest.mark.asyncio
+async def test_projector_service_analyze_skills_paginates_and_enriches_api_skills():
+    jobs = [
+        {"skills": ["skill-python", "skill-sql"], "sectors": ["Education"]},
+        {"skills": ["skill-python"], "sectors": ["Research"]},
+    ]
+    fake_service, _, fake_tracker, _ = _make_projector_service(jobs)
+
+    result = await fake_service.analyze_skills(
+        min_date="2024-01-01",
+        max_date="2024-01-31",
+        page=2,
+        page_size=1,
+        demo=True,
+        include_sectoral=False,
+    )
+
+    assert result["status"] == "completed"
+    assert result["dimension_summary"]["jobs_analyzed"] == 2
+    assert result["insights"]["ranking"] == [{"id": "skill-sql", "name": "SQL"}]
+    assert result["insights"]["regional"] == [{"location": "IT", "demo": True, "count": 2}]
+    assert result["insights"]["sectoral"] is None
+    assert set(fake_tracker.skill_names_requested) == {"skill-python", "skill-sql"}
+
+
+@pytest.mark.asyncio
+async def test_projector_service_sectoral_uses_tracker_sectors_view():
+    jobs = [{"skills": ["skill-python"], "sectors": ["Education"]}]
+    fake_service, _, _, fake_sectoral = _make_projector_service(jobs)
+
+    result = await fake_service.analyze_skills(
+        min_date="2024-01-01",
+        max_date="2024-01-31",
+        page=1,
+        page_size=50,
+        include_sectoral=True,
+        sector_system="isco",
+        sector_level="nace_class",
+        skill_group_level=2,
+        occupation_level=3,
+    )
+
+    assert result["insights"]["sectoral_mode"] == "nace"
+    assert result["insights"]["sectoral_views"] == {
+        "nace": {
+            "sector_level": "tracker_sector",
+            "items": [{"sector": "Education", "observed_skills": [{"skill": "Python"}]}],
+        }
+    }
+    assert result["insights"]["sector_view_names"] == {"nace": {"observed": "Observed"}}
+    assert fake_sectoral.kwargs["jobs"] == jobs
+    assert fake_sectoral.kwargs["sector_level"] == "nace_section"
+    assert fake_sectoral.kwargs["skill_group_level"] == 2
+    assert fake_sectoral.kwargs["occupation_level"] == 3
+    assert fake_sectoral.kwargs["reset"] is True
+
+
+@pytest.mark.asyncio
+async def test_projector_service_emerging_skills_and_stop_status():
+    fake_service, fake_engine, _, _ = _make_projector_service([])
+
+    emerging = await fake_service.emerging_skills(
+        min_date="2024-01-01",
+        max_date="2024-01-31",
+        keywords=["python"],
+    )
+    stop_result = fake_service.stop()
+
+    assert emerging["status"] == "completed"
+    assert emerging["insights"]["filters"] == {"keywords": ["python"]}
+    assert stop_result == {"status": "signal_sent"}
+    assert fake_engine.stop_requested is True
+
 
 @pytest.mark.asyncio
 async def test_engine_analyze_market_data_logic():
@@ -200,6 +380,129 @@ async def test_fetch_all_jobs_read_timeout_resilience():
         # Deve catturare l'errore, loggare e restituire i job accumulati finora (vuoti)
         result = await tracker.fetch_all_jobs({"kw": "test"})
         assert result == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_skill_names_enriches_api_skills_and_requests_token():
+    engine.skill_map = {}
+    engine.token = None
+    engine.stop_requested = False
+
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {
+        "items": [
+            {"id": "skill-python", "label": "Python"},
+            {"id": "skill-sql", "label": "SQL"},
+        ]
+    }
+
+    async def fake_token():
+        engine.token = "fresh-token"
+        return engine.token
+
+    with patch.object(tracker, "_get_token", new_callable=AsyncMock) as mock_token, \
+         patch.object(engine.client, "post", new_callable=AsyncMock) as mock_post:
+        mock_token.side_effect = fake_token
+        mock_post.return_value = response
+
+        await tracker.fetch_skill_names(["skill-python", "skill-sql", "skill-python"])
+
+    assert mock_token.await_count == 1
+    assert mock_post.await_count == 1
+    assert mock_post.await_args.kwargs["headers"] == {"Authorization": "Bearer fresh-token"}
+    assert mock_post.await_args.kwargs["data"] == {
+        "ids": ["skill-python", "skill-sql", "skill-python"],
+        "keywords_logic": "or",
+    }
+    assert engine.skill_map["skill-python"] == {
+        "label": "Python",
+        "is_green": False,
+        "is_digital": False,
+    }
+    assert engine.skill_map["skill-sql"]["label"] == "SQL"
+
+
+@pytest.mark.asyncio
+async def test_fetch_skill_names_skips_cached_and_stopped_requests():
+    engine.skill_map = {"skill-python": {"label": "Python"}}
+    engine.stop_requested = False
+
+    with patch.object(engine.client, "post", new_callable=AsyncMock) as mock_post:
+        await tracker.fetch_skill_names(["skill-python"])
+        mock_post.assert_not_awaited()
+
+    engine.stop_requested = True
+    with patch.object(engine.client, "post", new_callable=AsyncMock) as mock_post:
+        await tracker.fetch_skill_names(["skill-sql"])
+        mock_post.assert_not_awaited()
+
+    engine.stop_requested = False
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_jobs_paginates_and_writes_sector_cache(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    engine.token = "fake-token"
+    engine.stop_requested = False
+
+    first = MagicMock()
+    first.status_code = 200
+    first.json.return_value = {
+        "count": 3,
+        "items": [
+            {"id": 1, "skills": ["skill-a"], "sectors": ["Education"]},
+            {"id": 2, "skills": ["skill-b"], "sectors": ["Research"]},
+        ],
+    }
+    second = MagicMock()
+    second.status_code = 200
+    second.json.return_value = {
+        "count": 3,
+        "items": [{"id": 3, "skills": ["skill-c"], "sectors": ["Manufacturing"]}],
+    }
+
+    with patch.object(engine.client, "post", new_callable=AsyncMock) as mock_post:
+        mock_post.side_effect = [first, second]
+        result = await tracker.fetch_all_jobs({"keywords": ["data"]}, page_size=2)
+
+    assert [job["id"] for job in result] == [1, 2, 3]
+    assert mock_post.await_count == 2
+    assert mock_post.await_args_list[0].kwargs["params"] == {"page": 1, "page_size": 2}
+    assert mock_post.await_args_list[1].kwargs["params"] == {"page": 2, "page_size": 2}
+    cache_files = list((tmp_path / "cache_data").glob("search_*.json"))
+    assert len(cache_files) == 1
+    assert json.loads(cache_files[0].read_text()) == result
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_jobs_uses_sector_cache_and_refetches_stale_cache(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    engine.token = "fake-token"
+    engine.stop_requested = False
+
+    query_sig = hashlib.md5(json.dumps({"keywords": ["data"]}, sort_keys=True).encode()).hexdigest()
+    cache_dir = tmp_path / "cache_data"
+    cache_dir.mkdir()
+    cache_file = cache_dir / f"search_{query_sig}.json"
+    cache_file.write_text(json.dumps([{"id": 1, "sectors": ["Education"]}]))
+
+    with patch.object(engine.client, "post", new_callable=AsyncMock) as mock_post:
+        cached = await tracker.fetch_all_jobs({"keywords": ["data"]})
+        mock_post.assert_not_awaited()
+    assert cached == [{"id": 1, "sectors": ["Education"]}]
+
+    cache_file.write_text(json.dumps([{"id": 2, "occupation_id": "old"}]))
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {"count": 1, "items": [{"id": 3, "sectors": ["Research"]}]}
+
+    with patch.object(engine.client, "post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = response
+        refreshed = await tracker.fetch_all_jobs({"keywords": ["data"]})
+
+    assert refreshed == [{"id": 3, "sectors": ["Research"]}]
+    assert mock_post.await_count == 1
 
 
 @pytest.mark.asyncio

--- a/app/test.py
+++ b/app/test.py
@@ -1081,6 +1081,25 @@ def test_normalize_nace_code_supports_uri_and_numeric_shapes():
     assert occupations.normalize_nace_code("A") == "A"
 
 
+def test_get_nace_mappings_from_job_reads_tracker_sectors_field():
+    from app.core.container import ProjectorEngine
+
+    engine = ProjectorEngine()
+    occupations = OccupationAnalytics(engine)
+
+    job = {
+        "sectors": [
+            {"code": "http://data.europa.eu/ux2/nace2.1/6201", "label": "Computer programming activities"},
+            {"naceCode": "J63.1", "naceLabel": "Data processing, hosting and related activities"},
+            "M70.22",
+        ]
+    }
+
+    assert occupations.get_sector_keys_from_job(job, level="nace_section") == ["J", "M"]
+    assert occupations.get_sector_keys_from_job(job, level="nace_division") == ["62", "63", "70"]
+    assert occupations.get_sector_keys_from_job(job, level="nace_class") == ["62.01", "63.1", "70.22"]
+
+
 def test_get_sector_label_uses_nace_dictionary_in_nace_mode():
     from app.core.container import ProjectorEngine
 
@@ -2576,6 +2595,67 @@ def test_endpoint_analyze_skills_sectoral_supports_nace_hierarchy_selection():
         assert "dominance_top10_share" in sector["sector_metrics"]
         assert len(sector["skill_transversal_insights"]) >= 1
         assert "sector_breadth" in sector["skill_transversal_insights"][0]
+
+
+@pytest.mark.integration
+def test_endpoint_analyze_skills_sectoral_prefers_tracker_job_sectors_for_nace():
+    form_data = {
+        "keywords": ["developer"],
+        "min_date": "2024-01-01",
+        "max_date": "2024-01-10",
+        "include_sectoral": True,
+        "sector_system": "nace",
+        "sector_level": "nace_class",
+        "skill_group_level": 1,
+        "occupation_level": 1,
+    }
+
+    fake_jobs = [
+        {
+            "occupation_id": "occ_1",
+            "skills": ["skill_obs"],
+            "sectors": [{"code": "M70.22", "label": "Business and other management consultancy activities"}],
+            "upload_date": "2024-01-02",
+        }
+    ]
+
+    with patch.object(tracker, "fetch_all_jobs", new_callable=AsyncMock) as m_fetch, \
+         patch.object(tracker, "fetch_skill_names", new_callable=AsyncMock) as m_fetch_skills, \
+         patch.object(tracker, "fetch_occupation_labels", new_callable=AsyncMock) as m_fetch_occ:
+
+        m_fetch.return_value = fake_jobs
+        m_fetch_skills.return_value = None
+        m_fetch_occ.return_value = None
+
+        engine.occupation_meta = {
+            "occ_1": {"label": "Software developer", "isco_group": "C2", "nace_code": "C10.11"},
+        }
+        engine.occupation_group_labels = {"C2": "C2"}
+        engine.occ_skill_relations = defaultdict(set)
+        engine.occ_skill_relations["occ_1"] = {"skill_a"}
+        engine.skill_map = {
+            "skill_a": {"label": "Python", "is_green": False, "is_digital": True},
+            "skill_obs": {"label": "Docker", "is_green": False, "is_digital": True},
+        }
+        engine.skill_hierarchy = {
+            "skill_a": {"level_1": "S1", "level_2": "S1.1", "level_3": "S1.1.1"},
+            "skill_obs": {"level_1": "S3", "level_2": "S3.1", "level_3": "S3.1.1"},
+        }
+        engine.esco_matrix_profiles = {
+            ("Matrix 1.1", "http://data.europa.eu/esco/isco/C2"): {
+                "occupation_group_label": "Professionals",
+                "profile": {"S1": 1.0}
+            }
+        }
+
+        response = client.post("/projector/analyze-skills", data=form_data)
+        assert response.status_code == 200
+
+        data = response.json()
+        sector = data["insights"]["sectoral"][0]
+        assert sector["sector"] == "70.22"
+        assert sector["sector_label"] == "Business and other management consultancy activities"
+        assert data["insights"]["sectors"][0]["name"] == "M"
 
 @pytest.mark.integration
 def test_endpoint_analyze_skills_sectoral_uses_isco_when_sector_system_is_isco():

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,12 +7,13 @@ This folder contains the maintained documentation for the current `app/` impleme
 1. [Overview](overview.md) explains what the service does and who it is for.
 2. [Endpoint cheatsheet](endpoint-cheatsheet.md) gives a compact consumer-facing schema of what each endpoint returns.
 3. [API reference](api-reference.md) documents current public endpoints and form fields.
-4. [Data model](data-model.md) explains response fields and metric semantics.
-5. [Architecture](architecture.md) maps the runtime flow to the current code.
-6. [Examples](examples.md) provides request examples and frontend integration patterns.
-7. [Sector intelligence](sector-intelligence.md) explains ISCO/NACE sectoral analytics.
-8. [Data sources](data-sources.md) explains Tracker, ESCO CSV files, ESCO matrix and ESCO-NACE crosswalk usage.
-9. [Issue management](issue-management.md) defines issue labels, Project statuses and decision/implementation flows.
+4. [Data model](data-model.md) explains response fields.
+5. [Statistics](statistic.md) explains metric formulas.
+6. [Architecture](architecture.md) maps the runtime flow to the current code.
+7. [Examples](examples.md) provides request examples and frontend integration patterns.
+8. [Sector intelligence](sector-intelligence.md) explains Tracker API sector analytics.
+9. [Data sources](data-sources.md) explains Tracker API data usage.
+10. [Issue management](issue-management.md) defines issue labels, Project statuses and decision/implementation flows.
 
 ## Current Code Layout
 

--- a/docs/US alligment T3.5-v02.md
+++ b/docs/US alligment T3.5-v02.md
@@ -19,16 +19,10 @@ insights.regional
 ## Sectoral Intelligence
 
 Current support:
-- ISCO sector view,
-- NACE sector view through ESCO-NACE crosswalk,
-- NACE levels: section, division, group, class,
+- observed Tracker API sector view,
 - observed skills,
-- canonical ESCO skills,
 - observed skill groups,
-- canonical skill groups,
-- official ESCO matrix groups,
-- skill breadth and concentration metrics,
-- ISCO observed/canonical gap interpretation.
+- skill breadth and concentration metrics.
 
 Relevant response fields:
 
@@ -61,12 +55,11 @@ Current support:
 - Location Quotient-like specialization,
 - sector breadth,
 - dominant sector share,
-- top-10 sector dominance,
-- observed/canonical overlap for ISCO.
+- top-10 sector dominance.
 
 ## Current Gaps
 
 - Error responses are not standardized.
 - Date ordering is not explicitly validated.
 - Green and digital flags are currently placeholders in runtime enrichment.
-- Automated test coverage should be expanded for all NACE levels and no-data branches.
+- Automated test coverage should be expanded for API-only sector payloads and no-data branches.

--- a/docs/User Story Example-v01.md
+++ b/docs/User Story Example-v01.md
@@ -21,19 +21,17 @@ If the analyst enables sectoral intelligence, the dashboard sends:
 
 ```text
 include_sectoral=true
-sector_system=both
-sector_level=nace_section
+sector_system=nace
 ```
 
 The response includes:
-- ISCO sectoral data under `insights.sectoral_views.isco`
-- NACE level data under `insights.sectoral_views.nace.levels`
+- observed sectoral data under `insights.sectoral_views.nace.items`
 - display names under `insights.sector_view_names`
 
 ## Acceptance Criteria
 
 - The user can launch a full analysis from the dashboard.
 - The dashboard can render skills, trends, geography, employers and titles.
-- The dashboard can switch between ISCO and NACE sector views.
-- NACE level switching updates the active NACE sectoral payload.
+- The dashboard can render Tracker API sector views.
+- The dashboard does not expose sector hierarchy switching because Tracker returns sector labels.
 - The stop button calls `POST /projector/stop` and treats it as cooperative cancellation.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -32,10 +32,10 @@ Runs the main labor-market analysis.
 | `page_size` | integer | no | `50` | Number of ranking items returned |
 | `demo` | boolean | no | `false` | Enables synthetic NUTS-like projection for country-level locations |
 | `include_sectoral` | boolean | no | `false` | Enables sectoral intelligence payload |
-| `sector_system` | enum | no | `isco` | `isco`, `nace`, or `both` |
-| `sector_level` | enum | no | `isco_group` | `isco_group`, `nace_section`, `nace_division`, `nace_group`, `nace_class`, `nace_code` |
-| `skill_group_level` | integer | no | `1` | ESCO skill group level used in sector group aggregation |
-| `occupation_level` | integer | no | `1` | ESCO occupation level used for official matrix lookup |
+| `sector_system` | enum | no | `isco` | Accepted for compatibility; runtime uses `nace` |
+| `sector_level` | enum | no | `isco_group` | Accepted for compatibility; runtime uses Tracker sector labels |
+| `skill_group_level` | integer | no | `1` | Accepted for compatibility |
+| `occupation_level` | integer | no | `1` | Accepted for compatibility |
 
 `page` and `page_size` do not paginate Tracker fetching. They only slice the returned top-skill ranking.
 
@@ -52,10 +52,7 @@ curl -X POST "http://127.0.0.1:8000/projector/analyze-skills" \
   -d "page_size=20" \
   -d "demo=false" \
   -d "include_sectoral=true" \
-  -d "sector_system=both" \
-  -d "sector_level=nace_section" \
-  -d "skill_group_level=1" \
-  -d "occupation_level=1"
+  -d "sector_system=nace"
 ```
 
 ### Response Shape
@@ -78,7 +75,7 @@ curl -X POST "http://127.0.0.1:8000/projector/analyze-skills" \
         "is_green": false,
         "is_digital": false,
         "sector_spread": 4,
-        "primary_sector": "Software developers"
+        "primary_sector": "Information and communication"
       }
     ],
     "sectors": [],
@@ -98,32 +95,16 @@ curl -X POST "http://127.0.0.1:8000/projector/analyze-skills" \
       "nuts3": []
     },
     "sectoral": [],
-    "sectoral_mode": "both",
+    "sectoral_mode": "nace",
     "sectoral_views": {
-      "isco": {
-        "sector_level": "isco_group",
-        "items": []
-      },
       "nace": {
-        "selected_level": "nace_section",
-        "levels": {
-          "nace_section": { "sector_level": "nace_section", "items": [] },
-          "nace_division": { "sector_level": "nace_division", "items": [] },
-          "nace_group": { "sector_level": "nace_group", "items": [] },
-          "nace_class": { "sector_level": "nace_class", "items": [] }
-        }
+        "sector_level": "tracker_sector",
+        "items": []
       }
     },
     "sector_view_names": {
-      "isco": {
-        "observed": "Observed",
-        "canonical": "Canonical",
-        "matrix": "Official Matrix"
-      },
       "nace": {
-        "observed": "Observed",
-        "canonical": "Derived Canonical",
-        "matrix": "Aggregated Official Matrix"
+        "observed": "Observed"
       }
     }
   }
@@ -133,6 +114,18 @@ curl -X POST "http://127.0.0.1:8000/projector/analyze-skills" \
 When `include_sectoral=false`, `sectoral`, `sectoral_mode`, `sectoral_views` and `sector_view_names` are returned as `null`.
 
 When no jobs are found, the service returns a completed response with `jobs_analyzed=0` and empty insight lists.
+
+## GET `/projector/health`
+
+Checks whether the Projector app is reachable.
+
+### Response Shape
+
+```json
+{
+  "status": "ok"
+}
+```
 
 ## POST `/projector/emerging-skills`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,6 @@ This document describes the maintained `app/` implementation.
 - Pydantic response models
 - file-based JSON cache for Tracker job batches
 - Streamlit dashboard for local exploration
-- `openpyxl` for ESCO workbook loading
 
 ## Current Module Flow
 
@@ -28,45 +27,35 @@ app.main
 
 Shared runtime state lives in `app.core.state.ProjectorEngine`.
 
-Dependency wiring and local ESCO loading happen in `app.core.container`:
-
-```text
-ProjectorEngine
-TrackerClient
-EscoLoader.load_local_esco_support()
-EscoLoader.load_official_esco_matrix()
-analytics services
-ProjectorService
-```
+Dependency wiring happens in `app.core.container`. Local ESCO loaders are not executed at startup for the current API-only sector workflow.
 
 ## External Tracker Dependency
 
 The Projector depends on the SKILLAB Tracker for raw job data and metadata enrichment.
 
 Tracker endpoints used internally:
+
 - `POST /login`
 - `POST /jobs`
 - `POST /skills`
-- `POST /occupations`
 
-Projector latency and failure modes are therefore partly determined by Tracker availability and response time.
+Projector latency and failure modes are determined mostly by Tracker availability and response time.
 
 ## Main Analysis Flow
 
-`POST /projector/analyze-skills` currently follows this flow:
+`POST /projector/analyze-skills` follows this flow:
 
 1. Reset the cooperative stop flag.
 2. Build a clean Tracker filter payload.
 3. Fetch all matching jobs from Tracker or `cache_data/`.
-4. Return an empty but structured payload if no jobs are found.
-5. Extract all occupations and observed skills from jobs.
-6. Add canonical ESCO skills linked to observed occupations so labels can be resolved.
-7. Resolve occupation labels and skill labels.
-8. Compute market rankings.
-9. Compute trends from the already fetched in-memory job batch.
-10. Compute regional projections.
-11. If `include_sectoral=true`, build ISCO and all NACE sectoral views.
-12. Return the Pydantic-modeled response.
+4. Return an empty structured payload if no jobs are found.
+5. Extract observed skills and sectors from jobs.
+6. Resolve skill labels from Tracker `/skills`.
+7. Compute market rankings.
+8. Compute trends from the fetched in-memory job batch.
+9. Compute regional projections.
+10. If `include_sectoral=true`, build the observed sector-skill view from `job["sectors"]` and `job["skills"]`.
+11. Return the Pydantic-modeled response.
 
 ## Caching
 
@@ -76,28 +65,28 @@ Tracker job batches are cached in:
 cache_data/search_<md5-filter-hash>.json
 ```
 
-The cache key is derived from the cleaned Tracker filter payload.
-
 Important behavior:
-- repeated identical filters reuse the cache,
-- cache entries do not currently expire,
-- changing Tracker data is not reflected until matching cache files are removed or invalidated.
+
+- repeated identical filters reuse the cache
+- cache entries do not expire automatically
+- cached job batches without `sectors` are treated as stale and refetched
 
 ## Stop Behavior
 
 `POST /projector/stop` sets `engine.stop_requested=True`.
 
 This is cooperative interruption:
-- it does not kill the Python process,
-- long-running code checks the flag at safe points,
-- final endpoint status can become `stopped` if the running request observes the flag.
+
+- it does not kill the Python process
+- long-running code checks the flag at safe points
+- final endpoint status can become `stopped` if the running request observes the flag
 
 ## Trend Strategy
 
 The code supports two trend paths:
 
-- `calculate_trends_from_data`: compares two halves of the already fetched job batch.
-- `calculate_smart_trends`: fetches two sub-periods independently.
+- `calculate_trends_from_data`: compares two halves of the already fetched job batch
+- `calculate_smart_trends`: fetches two sub-periods independently
 
 `/projector/analyze-skills` uses the in-memory path. `/projector/emerging-skills` uses the trend-only path.
 
@@ -110,29 +99,23 @@ Regional analytics use:
 
 When `demo=true`, country-level location codes can be expanded into synthetic NUTS-like codes to demonstrate regional drill-down behavior.
 
-## Sector-Resolution Strategy
+## Sector Strategy
 
-ISCO path:
-
-```text
-occupation -> isco_group -> ISCO label
-```
-
-NACE path:
+Sector analytics use only Tracker job fields:
 
 ```text
-occupation -> ESCO-NACE crosswalk -> NACE code/title
+job["sectors"] x job["skills"]
 ```
 
-One occupation can map to multiple NACE codes. All mappings are currently kept.
+One job can contain multiple sectors and multiple skills. Every sector-skill pair in the same job contributes to the observed sector-skill matrix.
 
 ## Current Caveats
 
 - There is no standardized error response model.
 - Date ordering is not explicitly validated.
-- Cache invalidation is manual.
+- Cache invalidation is mostly manual.
 - Green and digital flags are currently false by default in runtime enrichment.
-- NACE mode is relation-oriented, so NACE counts should not be interpreted as strict one-job-one-sector accounting.
+- Sector counts are relationship-oriented when one job has many sectors.
 - The shared `ProjectorEngine` state is process-local and in-memory.
 
 ## Production Hardening Priorities
@@ -141,5 +124,5 @@ One occupation can map to multiple NACE codes. All mappings are currently kept.
 2. Define a standard error envelope.
 3. Add explicit cache invalidation or TTL.
 4. Add versioning, for example `/api/v1/projector/...`.
-5. Add health/readiness endpoints for Tracker and local ESCO resources.
-6. Expand automated tests for ISCO/NACE sectoral payloads and no-data responses.
+5. Extend `/projector/health` with Tracker readiness.
+6. Expand automated tests for API-only sectoral payloads and no-data responses.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,6 +1,6 @@
-# Data Model and Metric Semantics
+# Data Model
 
-This document explains the response fields returned by the current API models in `app/schemas/responses.py`.
+This document describes current response fields. Metric formulas live in [Statistics](statistic.md).
 
 ## Root Response
 
@@ -14,15 +14,7 @@ This document explains the response fields returned by the current API models in
 }
 ```
 
-`status` is usually:
-- `completed`
-- `stopped`
-
-`POST /projector/stop` returns:
-
-```json
-{ "status": "signal_sent" }
-```
+`status` is usually `completed` or `stopped`.
 
 ## Dimension Summary
 
@@ -35,30 +27,23 @@ This document explains the response fields returned by the current API models in
 }
 ```
 
-Fields:
-- `jobs_analyzed`: number of Tracker job records processed by the endpoint.
-- `geo_breakdown`: count by raw `location_code`.
+- `jobs_analyzed`: Tracker jobs processed.
+- `geo_breakdown`: job count by raw `location_code`.
 
 ## Insights
 
-The main `insights` object contains:
+Main fields:
 
-- `ranking`
-- `sectors`
-- `job_titles`
-- `employers`
-- `trends`
-- `regional`
-- `sectoral`
-- `sectoral_mode`
-- `sectoral_views`
-- `sector_view_names`
-
-The last four fields are meaningful when `include_sectoral=true`; otherwise they are `null`.
+- `ranking`: top observed skills.
+- `sectors`: top Tracker sectors.
+- `job_titles`: most frequent job titles.
+- `employers`: most frequent employers.
+- `trends`: skill and volume changes between two time slices.
+- `regional`: geographic breakdown.
+- `sectoral`: observed sector intelligence when `include_sectoral=true`.
+- `sectoral_views`: NACE view wrapper for dashboard use.
 
 ## Skill Ranking
-
-Each item in `insights.ranking` has:
 
 ```json
 {
@@ -68,22 +53,15 @@ Each item in `insights.ranking` has:
   "is_green": false,
   "is_digital": false,
   "sector_spread": 4,
-  "primary_sector": "Software developers"
+  "primary_sector": "Information and communication"
 }
 ```
 
-Fields:
-- `name`: resolved skill label when available.
-- `frequency`: number of times the skill appears in the analyzed jobs.
-- `skill_id`: original skill URI/id.
-- `is_green`: green-skill flag. Currently false by default in runtime enrichment.
-- `is_digital`: digital-skill flag. Currently false by default in runtime enrichment.
-- `sector_spread`: number of distinct ISCO sectors associated with this skill in the analyzed batch.
-- `primary_sector`: most frequent ISCO sector for this skill.
+`sector_spread` and `primary_sector` are based on Tracker `job["sectors"]`.
 
 ## Count Lists
 
-`insights.sectors`, `insights.job_titles` and `insights.employers` use:
+`sectors`, `job_titles` and `employers` use:
 
 ```json
 {
@@ -92,227 +70,66 @@ Fields:
 }
 ```
 
-`sectors` in the base ranking path is ISCO-oriented. NACE-specific sectoral data lives in `insights.sectoral_views.nace`.
+## Sectoral View
 
-## Trends
-
-```json
-{
-  "market_health": {
-    "status": "expanding",
-    "volume_growth_percentage": 12.5
-  },
-  "trends": [
-    {
-      "name": "Python",
-      "growth": 20.0,
-      "trend_type": "emerging",
-      "primary_sector": "Software developers",
-      "is_green": false,
-      "is_digital": false
-    }
-  ]
-}
-```
-
-Trend calculation compares two halves of the selected date range.
-
-`growth` can be:
-- a numeric percentage,
-- `"new_entry"` when the skill was absent in the first half and present in the second.
-
-`trend_type` can be:
-- `emerging`
-- `declining`
-- `stable`
-
-`market_health.status` is currently computed from total job volume and is normally `expanding` or `shrinking`.
-
-## Regional Projections
+Current sectoral view is observed-only and API-only:
 
 ```json
 {
-  "raw": [],
-  "nuts1": [],
-  "nuts2": [],
-  "nuts3": []
-}
-```
-
-Each regional area item has:
-
-```json
-{
-  "code": "ITC4",
-  "total_jobs": 120,
-  "market_share": 9.6,
-  "top_skills": [
-    {
-      "skill": "Python",
-      "count": 33,
-      "specialization": 1.78
-    }
-  ]
-}
-```
-
-Fields:
-- `code`: raw or projected geographic code.
-- `total_jobs`: jobs assigned to the area.
-- `market_share`: percentage of all analyzed jobs represented by the area.
-- `top_skills`: most frequent skills in the area.
-- `specialization`: Location Quotient-like score. Values above `1` indicate above-average local concentration compared with the full analyzed market.
-
-## Sectoral Item
-
-Each sectoral item can contain:
-
-```json
-{
-  "sector": "C25",
-  "sector_label": "Information and communication",
-  "observed_skills": {},
-  "canonical_skills": {},
-  "observed_groups": {},
-  "canonical_groups": {},
-  "matrix_groups": {},
-  "sector_metrics": {},
-  "skill_transversal_insights": [],
-  "isco_interpretation": null
-}
-```
-
-## Sector Skill Summary
-
-Used by `observed_skills` and `canonical_skills`:
-
-```json
-{
-  "sector": "C25",
-  "total_skill_mentions": 100,
-  "unique_skills": 25,
-  "top_skills": [
-    {
-      "skill_id": "http://data.europa.eu/esco/skill/...",
-      "count": 10,
-      "frequency": 0.1,
-      "label": "Python",
-      "is_green": false,
-      "is_digital": false
-    }
-  ]
-}
-```
-
-`observed_skills` comes from Tracker job evidence. `canonical_skills` comes from ESCO occupation-skill relations.
-
-## Sector Group Summary
-
-Used by `observed_groups`, `canonical_groups` and `matrix_groups`:
-
-```json
-{
-  "total_group_mentions": 100.0,
-  "unique_groups": 8,
-  "top_groups": [
-    {
-      "group_id": "S4",
-      "group_label": "Working with computers",
-      "count": 30.0,
-      "frequency": 0.3
-    }
-  ]
-}
-```
-
-## Sector Metrics
-
-```json
-{
-  "coverage_unique_skills": 25,
-  "dominance_top10_share": 0.72
-}
-```
-
-Fields:
-- `coverage_unique_skills`: number of unique observed skills in the sector.
-- `dominance_top10_share`: share of observed skill mentions represented by the top 10 skills.
-
-## Skill Transversal Insights
-
-```json
-{
-  "skill_id": "http://data.europa.eu/esco/skill/...",
-  "label": "Python",
-  "count": 10,
-  "importance_in_sector": 0.1,
-  "sector_breadth": 4,
-  "dominant_sector": "J",
-  "dominant_sector_label": "Information and communication",
-  "dominant_share": 0.52,
-  "top_sectors": [
-    {
-      "sector": "J",
-      "sector_label": "Information and communication",
-      "count": 52,
-      "share": 0.52
-    }
-  ]
-}
-```
-
-Fields:
-- `importance_in_sector`: share of a skill inside the current sector.
-- `sector_breadth`: number of sectors where the skill appears.
-- `dominant_share`: share of all mentions for that skill found in the dominant sector.
-
-## ISCO Interpretation
-
-Only ISCO sectoral items include `isco_interpretation`.
-
-```json
-{
-  "sector": "C25",
-  "emerging_skills": [],
-  "missing_skills": [],
-  "stability_overlap": 0.42,
-  "observed_skill_count": 30,
-  "canonical_skill_count": 80,
-  "overlap_skill_count": 20
-}
-```
-
-Fields:
-- `emerging_skills`: observed skills not present in canonical ESCO relations.
-- `missing_skills`: canonical skills not observed in the current market slice.
-- `stability_overlap`: Jaccard overlap between observed and canonical skill sets.
-
-## Sectoral Views
-
-`insights.sectoral_views` contains both systems:
-
-```json
-{
-  "isco": {
-    "sector_level": "isco_group",
-    "items": []
-  },
-  "nace": {
-    "selected_level": "nace_section",
-    "levels": {
-      "nace_section": { "sector_level": "nace_section", "items": [] },
-      "nace_division": { "sector_level": "nace_division", "items": [] },
-      "nace_group": { "sector_level": "nace_group", "items": [] },
-      "nace_class": { "sector_level": "nace_class", "items": [] }
+  "sectoral_mode": "nace",
+  "sectoral_views": {
+    "nace": {
+      "sector_level": "tracker_sector",
+      "items": []
     }
   }
 }
 ```
 
-NACE canonical and matrix groups are ESCO-derived projections aggregated through the ESCO-NACE crosswalk.
+## Sectoral Item
 
-## Interpretation Caveats
+```json
+{
+  "sector": "Information and communication",
+  "sector_label": "Information and communication",
+  "observed_skills": {},
+  "observed_groups": {},
+  "sector_metrics": {},
+  "skill_transversal_insights": []
+}
+```
 
-- `frequency` means count in the top ranking, but relative share inside nested sector summaries.
-- NACE is multi-mapping aware; NACE sector totals are relation counts, not strict unique job counts.
-- `demo=true` regional projections are synthetic when source location codes are only country-level.
+## Observed Skills
+
+```json
+{
+  "sector": "Information and communication",
+  "total_skill_mentions": 100,
+  "unique_skills": 25,
+  "top_skills": [
+    {
+      "skill_id": "http://data.europa.eu/esco/skill/...",
+      "label": "Python",
+      "count": 10,
+      "frequency": 0.1,
+      "is_green": false,
+      "is_digital": false
+    }
+  ]
+}
+```
+
+## Skill Transversal Insights
+
+```json
+{
+  "label": "Python",
+  "count": 10,
+  "importance_in_sector": 0.1,
+  "sector_breadth": 4,
+  "dominant_sector_label": "Information and communication",
+  "dominant_share": 0.52
+}
+```
+
+These fields explain how a selected sector's top skills behave across all sectors in the result.

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -1,87 +1,38 @@
 # Data Sources
 
-SKILLAB Projector combines external Tracker data with local ESCO support files.
+SKILLAB Projector runtime uses Tracker API data for the current dashboard flow.
 
-## Source Summary
+## Runtime Sources
 
-| Source | File or endpoint | Current use |
+| Source | Endpoint / field | Use |
 | --- | --- | --- |
-| Tracker jobs | `POST {TRACKER_API}/jobs` | Raw job postings used for observed market evidence |
-| Tracker skills | `POST {TRACKER_API}/skills` | Skill label enrichment |
-| Tracker occupations | `POST {TRACKER_API}/occupations` | Occupation label fallback |
-| ESCO occupations | `complementary_data/occupations_en.csv` | Occupation metadata and ISCO fallback data |
-| ISCO groups | `complementary_data/ISCOGroups_en.csv` | ISCO group labels |
-| ESCO occupation-skill relations | `complementary_data/occupationSkillRelations_en.csv` | Canonical skill relations |
-| ESCO skill hierarchy | `complementary_data/skillsHierarchy_en.csv` | Skill group aggregation |
-| ESCO skill groups | `complementary_data/skillGroups_en.csv` | Skill group labels |
-| ESCO matrix workbook | `complementary_data/Skills_Occupations Matrix Tables_ESCOv1.2.0_1.xlsx` | Official matrix group profiles |
-| ESCO-NACE crosswalk | `complementary_data/ESCO-NACE rev. 2.1 crosswalk (1).xlsx` | Preferred occupation-to-NACE mapping and NACE titles |
-| NACE labels | `complementary_data/nace_codes_2_1.csv` | NACE label fallback |
+| Jobs | `POST {TRACKER_API}/jobs` | Raw job records |
+| Skills | `job["skills"]` | Observed skill ids |
+| Sectors | `job["sectors"]` | Observed sector labels |
+| Locations | `job["location_code"]`, `nuts1`, `nuts2`, `nuts3` | Regional breakdown |
+| Job titles | `job["title"]` | Job-title ranking |
+| Employers | `job["organization"]` / fallback fields | Employer ranking |
+| Skill labels | `POST {TRACKER_API}/skills` | Skill id to readable label |
 
-## Runtime Loading
+## Not Loaded In Runtime
 
-Local source loading happens during container setup:
+The current API-only flow does not load:
 
-```text
-app.core.container
- -> EscoLoader.load_local_esco_support()
- -> EscoLoader.load_official_esco_matrix()
-```
+- `occupationSkillRelations_en.csv`
+- `skillGroups_en.csv`
+- `skillsHierarchy_en.csv`
+- `occupations_en.csv`
+- `ISCOGroups_en.csv`
+- ESCO-NACE crosswalk workbook
+- NACE labels CSV
+- official ESCO matrix workbook
 
-The service is tolerant of missing optional files. Missing resources are logged as warnings and the corresponding layer may be incomplete.
+## Sector-Skill Source
 
-## Tracker vs Local ESCO Metadata
-
-Some occupation metadata can be requested from Tracker at runtime. In particular, Tracker has an occupation endpoint that accepts ids and returns labels.
-
-For static ESCO-derived metadata, the implementation can also use local CSV files instead of calling Tracker repeatedly. This is acceptable for ISCO support because the CSV files are ESCO sources and are stable enough to use as local reference data.
-
-Important distinction:
-- Tracker occupation labels are useful for display and fallback enrichment.
-- ESCO CSV occupation metadata is used for stable ISCO group resolution.
-- A preferred label alone should not be treated as the full ISCO mapping unless the explicit ISCO group metadata is also available.
-
-## Observed vs Canonical vs Matrix
-
-Observed data comes from Tracker jobs:
+Sector-skill statistics are built only from job co-occurrence:
 
 ```text
-job -> skills
-job -> occupations
+job["sectors"] x job["skills"]
 ```
 
-Canonical data comes from ESCO occupation-skill relations:
-
-```text
-occupation -> canonical skills
-```
-
-Skill group aggregation comes from ESCO hierarchy:
-
-```text
-skill -> skill group
-```
-
-Official matrix profiles come from the ESCO matrix workbook:
-
-```text
-occupation group -> skill group shares
-```
-
-NACE aggregation comes from the ESCO-NACE crosswalk:
-
-```text
-occupation -> one or more NACE codes/titles
-```
-
-## Important Semantics
-
-`occupations_en.csv` may contain a single `naceCode`, but the preferred NACE-facing source is the ESCO-NACE crosswalk workbook because it supports one-to-many mappings and NACE titles.
-
-When the crosswalk is available, NACE mode should be understood as:
-
-```text
-job -> occupation -> crosswalk mappings -> NACE sectors
-```
-
-When it is not available, the loader can fall back to `naceCode` values from `occupations_en.csv` where present.
+No occupation-to-sector mapping is used.

--- a/docs/endpoint-cheatsheet.md
+++ b/docs/endpoint-cheatsheet.md
@@ -8,7 +8,7 @@ For full field details, see [API reference](api-reference.md) and [Data model](d
 
 | Endpoint | Use it when you need | Returns in one sentence |
 | --- | --- | --- |
-| `POST /projector/analyze-skills` | A full dashboard snapshot | Skills, sectors, employers, titles, trends, geography and optional ISCO/NACE sectoral intelligence |
+| `POST /projector/analyze-skills` | A full dashboard snapshot | Skills, sectors, employers, titles, trends, geography and optional Tracker sector intelligence |
 | `POST /projector/emerging-skills` | Only trend information | Market volume trend plus emerging, declining, stable and new-entry skills |
 | `POST /projector/stop` | To interrupt a long analysis | Acknowledgement that a cooperative stop signal was sent |
 
@@ -35,8 +35,7 @@ curl -X POST "http://127.0.0.1:8000/projector/analyze-skills" \
   -d "min_date=2024-01-01" \
   -d "max_date=2024-12-31" \
   -d "include_sectoral=true" \
-  -d "sector_system=both" \
-  -d "sector_level=nace_section"
+  -d "sector_system=nace"
 ```
 
 ### What It Returns
@@ -71,28 +70,26 @@ curl -X POST "http://127.0.0.1:8000/projector/analyze-skills" \
 | `dimension_summary.jobs_analyzed` | Number of Tracker jobs analyzed | KPI card |
 | `dimension_summary.geo_breakdown` | Raw job counts by location code | Small table or map input |
 | `insights.ranking` | Top skills with count and sector context | Top skills chart |
-| `insights.sectors` | Base ISCO-oriented sector counts | Sector bar chart |
+| `insights.sectors` | Tracker sector counts | Sector bar chart |
 | `insights.job_titles` | Most frequent job titles | Job-title leaderboard |
 | `insights.employers` | Most frequent employers | Employer leaderboard |
 | `insights.trends` | Volume growth and skill trend changes | Trend tab |
 | `insights.regional` | Raw and NUTS-like area breakdowns with specialization | Map and regional detail |
 | `insights.sectoral` | Selected/default sectoral intelligence payload | Backward-compatible sector panel |
-| `insights.sectoral_views` | Full ISCO and NACE sectoral payloads | ISCO/NACE switcher and detail views |
-| `insights.sector_view_names` | Display labels for observed/canonical/matrix views | UI labels |
+| `insights.sectoral_views` | NACE wrapper with Tracker sector items | Sector detail views |
+| `insights.sector_view_names` | Display labels for observed views | UI labels |
 
 ### Sectoral Meaning In One Minute
 
 When `include_sectoral=false`, ignore the `sectoral*` fields.
 
 When `include_sectoral=true`:
-- ISCO answers: "What kind of job is this?"
-- NACE answers: "In which industry does this job operate?"
-- Observed means skills found in Tracker jobs.
-- Canonical means skills from ESCO occupation-skill relations.
-- Official Matrix means ESCO matrix skill-group profiles.
-- NACE Derived Canonical and Aggregated Official Matrix are ESCO-derived views re-aggregated through the ESCO-NACE crosswalk.
+- sectors come from Tracker `job["sectors"]`,
+- skills come from Tracker `job["skills"]`,
+- observed sector-skill counts come from job co-occurrence,
+- no ISCO, canonical, matrix, or ESCO-NACE crosswalk data is used.
 
-Important: NACE supports multiple mappings per occupation, so NACE totals describe skill-sector relationships, not strict unique job counts.
+Important: sector totals are relationship counts. A job with multiple sectors contributes to each listed sector.
 
 ## `POST /projector/emerging-skills`
 
@@ -132,7 +129,7 @@ curl -X POST "http://127.0.0.1:8000/projector/emerging-skills" \
 | `trends[].name` | Skill label |
 | `trends[].growth` | Growth percentage, or `new_entry` |
 | `trends[].trend_type` | `emerging`, `declining`, or `stable` |
-| `trends[].primary_sector` | Main ISCO sector associated with the skill |
+| `trends[].primary_sector` | Main Tracker sector associated with the skill |
 
 ## `POST /projector/stop`
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -17,15 +17,16 @@ curl -X POST "http://127.0.0.1:8000/projector/analyze-skills" \
 ```
 
 Use the response like this:
+
 - `dimension_summary.jobs_analyzed`: KPI tile
 - `insights.ranking`: top-skills chart
-- `insights.sectors`: ISCO-oriented sector bar chart
+- `insights.sectors`: Tracker sector bar chart
 - `insights.job_titles`: title leaderboard
 - `insights.employers`: employer leaderboard
 - `insights.trends`: trend tab
 - `insights.regional`: map and specialization widgets
 
-## Example 2: Full Snapshot With ISCO/NACE Sectoral Views
+## Example 2: Snapshot With Sector Intelligence
 
 ```bash
 curl -X POST "http://127.0.0.1:8000/projector/analyze-skills" \
@@ -35,32 +36,25 @@ curl -X POST "http://127.0.0.1:8000/projector/analyze-skills" \
   -d "min_date=2024-01-01" \
   -d "max_date=2024-12-31" \
   -d "include_sectoral=true" \
-  -d "sector_system=both" \
-  -d "sector_level=nace_section" \
+  -d "sector_system=nace" \
   -d "skill_group_level=1" \
   -d "occupation_level=1"
 ```
 
 Frontend usage:
-- read ISCO from `insights.sectoral_views.isco.items`
-- read NACE levels from `insights.sectoral_views.nace.levels`
-- use `insights.sectoral_views.nace.selected_level` as the default NACE tab or selector value
-- use `insights.sector_view_names` for display labels
 
-## Example 3: NACE Class View
+- read sectors from `insights.sectors`
+- read sector details from `insights.sectoral_views.nace.items`
+- display `observed_skills` for the selected sector
+- display `skill_transversal_insights` to show where selected-sector skills also appear
+
+## Example 3: Backend Health Check
 
 ```bash
-curl -X POST "http://127.0.0.1:8000/projector/analyze-skills" \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "keywords=data" \
-  -d "min_date=2024-01-01" \
-  -d "max_date=2024-12-31" \
-  -d "include_sectoral=true" \
-  -d "sector_system=nace" \
-  -d "sector_level=nace_class"
+curl "http://127.0.0.1:8000/projector/health"
 ```
 
-`insights.sectoral` will contain the selected NACE class payload. `insights.sectoral_views` will still contain the full ISCO and NACE level map.
+Use this before running a long dashboard request.
 
 ## Example 4: Trend-Only Widget
 
@@ -75,6 +69,7 @@ curl -X POST "http://127.0.0.1:8000/projector/emerging-skills" \
 ```
 
 Interpretation:
+
 - `market_health.status = expanding`: job volume grew in the second half of the window
 - `trend_type = emerging`: the skill gained relevance
 - `growth = "new_entry"`: the skill was absent in the first half and present in the second
@@ -86,9 +81,10 @@ curl -X POST "http://127.0.0.1:8000/projector/stop"
 ```
 
 Treat this as cooperative cancel:
-- show a stopping state,
-- do not assume instant interruption,
-- inspect the final analysis `status` when the running request returns.
+
+- show a stopping state
+- do not assume instant interruption
+- inspect the final analysis `status` when the running request returns
 
 ## Example 6: Reading Specialization
 
@@ -106,21 +102,12 @@ Suppose a regional item contains:
 ```
 
 Correct interpretation:
-- the area represents `9.6%` of the analyzed batch,
-- `Python` appears 33 times in that area,
-- `specialization = 1.78` means Python is more concentrated there than in the full analyzed market.
+
+- the area represents `9.6%` of the analyzed batch
+- `Python` appears 33 times in that area
+- `specialization = 1.78` means Python is more concentrated there than in the full analyzed market
 
 Do not read specialization as raw popularity alone.
-
-## Example 7: Demo Regional Mode
-
-If `demo=true` and the source jobs only carry country-level location codes, the service distributes jobs across synthetic NUTS-like areas.
-
-Recommended UI wording:
-
-```text
-Regional detail shown in demonstration mode. Sub-national distribution is simulated from country-level data.
-```
 
 ## Recommended Frontend Strategy
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,32 +2,28 @@
 
 SKILLAB Projector is a FastAPI analytics layer on top of the SKILLAB Tracker.
 
-The Tracker returns job-posting data. The Projector turns that data into aggregated intelligence for dashboards, analysts and integration clients.
+The Tracker returns job postings. The Projector turns those jobs into aggregated intelligence for dashboards, analysts, and integration clients.
 
 ## What It Answers
 
-The service helps answer:
-
-- which skills are most requested in a selected market slice,
-- which skills are emerging, declining or newly appearing,
-- which employers and job titles dominate hiring volume,
-- which locations show stronger concentration for a skill,
-- which skills characterize ISCO or NACE sectors,
-- how observed skills compare with ESCO canonical and matrix references.
+- which skills are most requested in a selected market slice
+- which skills are emerging, declining, or newly appearing
+- which employers and job titles dominate hiring volume
+- which locations show stronger concentration for a skill
+- which Tracker API sectors contain each skill
+- which skills are important inside a selected sector
 
 ## Main Users
 
-Developers:
-- need a stable API that returns aggregated intelligence instead of raw job lists.
+Developers need a stable API that returns aggregated intelligence instead of raw job lists.
 
-Dashboard authors:
-- need ready-to-visualize structures for rankings, trends, maps and sector drill-downs.
+Dashboard authors need ready-to-visualize structures for rankings, trends, maps, and sector drill-downs.
 
-Analysts and stakeholders:
-- need interpretable indicators without reading source code.
+Analysts need interpretable indicators without reading source code.
 
 ## Public Endpoints
 
+- `GET /projector/health`
 - `POST /projector/analyze-skills`
 - `POST /projector/emerging-skills`
 - `POST /projector/stop`
@@ -38,34 +34,24 @@ The main endpoint is `/projector/analyze-skills`.
 
 `/projector/analyze-skills` returns:
 
-- `dimension_summary`: analyzed job count and raw geographic breakdown,
-- `insights.ranking`: paginated top-skill ranking,
-- `insights.sectors`: base ISCO-oriented sector counts,
-- `insights.job_titles`: top job titles,
-- `insights.employers`: top employers,
-- `insights.trends`: market and skill trend analysis,
-- `insights.regional`: raw and NUTS-like geographic projections,
-- `insights.sectoral*`: optional ISCO/NACE sectoral intelligence.
+- `dimension_summary`: analyzed job count and raw geographic breakdown
+- `insights.ranking`: paginated top-skill ranking
+- `insights.sectors`: Tracker sector counts from `job["sectors"]`
+- `insights.job_titles`: top job titles
+- `insights.employers`: top employers
+- `insights.trends`: market and skill trend analysis
+- `insights.regional`: raw and NUTS-like geographic projections
+- `insights.sectoral_views.nace`: observed sector-skill intelligence from Tracker job sectors
 
-## Sector Systems
+## Sector Model
 
-ISCO is occupation-based:
-
-```text
-job -> occupation -> isco_group -> ISCO label
-```
-
-NACE is economic-activity-based:
+Sector intelligence is API-only:
 
 ```text
-job -> occupation -> ESCO-NACE crosswalk -> NACE code/title
+job["sectors"] x job["skills"] -> sector-skill matrix
 ```
 
-Both systems are useful and intentionally coexist:
-- ISCO is closer to occupational structure,
-- NACE is closer to economic activity.
-
-In NACE mode, canonical and matrix views are ESCO-derived projections aggregated through the ESCO-NACE crosswalk.
+The runtime does not use local occupation-sector files, local occupation-skill files, hierarchy files, or workbook mappings for sector intelligence.
 
 ## Current Entry Points
 

--- a/docs/sector-intelligence.md
+++ b/docs/sector-intelligence.md
@@ -1,219 +1,73 @@
 # Sector Intelligence
 
-Sector intelligence extends the base skills analysis with sector-oriented views built from occupations, skills and ESCO support files.
+Sector intelligence is now built from Tracker API job payloads only.
 
-## Sector Systems
+## Source
 
-The implementation supports two complementary sector systems.
+Each job can contain:
 
-| System | Meaning | Resolution path |
-| --- | --- | --- |
-| ISCO | Occupation-group view | `job -> occupation -> isco_group -> ISCO label` |
-| NACE | Economic-activity view | `job -> occupation -> ESCO-NACE crosswalk -> NACE code/title` |
+```text
+job["skills"]  -> ESCO skill ids
+job["sectors"] -> sector labels from Tracker
+```
 
-ISCO is native to the ESCO occupation structure. NACE is a projection through the ESCO-NACE crosswalk.
+The sector-skill matrix is built by co-occurrence inside the same job:
 
-ISCO classifies jobs and occupations. It answers: "What kind of job is this?"
+```text
+for each job:
+  for each sector in job["sectors"]:
+    for each skill in job["skills"]:
+      sector_skill_count[sector][skill] += 1
+```
 
-Examples:
-- Software Developer
-- Civil Engineer
-- Nurse
+If a job has no sectors, it is assigned to `Sector not specified`.
 
-NACE classifies economic sectors and industries. It answers: "In which industry does this job operate?"
+## Current Scope
 
-Examples:
-- Information and communication
-- Construction
-- Healthcare
+Only observed sectoral evidence is used.
 
-## ISCO Views
+Included:
+- Tracker jobs
+- Tracker skills
+- Tracker job sectors
 
-ISCO sectoral intelligence currently uses Tracker occupations and ESCO support files to build three views.
+Excluded from runtime:
+- ISCO comparison
+- ESCO-NACE crosswalk
+- local NACE labels
+- canonical ESCO occupation-skill relations
+- ESCO skill groups
+- official ESCO matrix
 
-| View | Occupation Source | ISCO Group Source | Skill Source | Skill Granularity | Aggregation Level |
-| --- | --- | --- | --- | --- | --- |
-| Observed | Tracker | ESCO CSV | Tracker | skill | ISCO group |
-| Canonical | Tracker | ESCO CSV | ESCO CSV relations | skill | ISCO group |
-| Official Matrix | Tracker | ESCO CSV | ESCO Matrix XLSX | skill group | ISCO group |
+## Payload
 
-The Tracker can resolve occupation labels through an endpoint that accepts occupation ids and returns labels. The implementation can also use ESCO CSV files directly for ISCO labels and group metadata. Since those CSV files come from ESCO, they are acceptable as local support data and avoid repeated Tracker calls for static metadata.
-
-The current ISCO grouping path relies on occupation metadata from ESCO CSV files, especially the occupation's ISCO group. Preferred occupation labels are useful for display, but they are not by themselves enough to define the ISCO group unless paired with the explicit group metadata.
-
-## NACE Views
-
-NACE sectoral intelligence uses Tracker occupations, the ESCO-NACE crosswalk and ESCO skill sources to build three corresponding views.
-
-| View | Occupation Source | NACE Source | Skill Source | Skill Granularity | Aggregation Level |
-| --- | --- | --- | --- | --- | --- |
-| Observed | Tracker | ESCO-NACE Crosswalk XLSX | Tracker | skill | NACE selected level |
-| Derived Canonical | Tracker | ESCO-NACE Crosswalk XLSX | ESCO CSV relations | skill | NACE selected level |
-| Aggregated Official Matrix | Tracker | ESCO-NACE Crosswalk XLSX | ESCO Matrix XLSX | skill group | NACE selected level |
-
-## NACE Levels
-
-The API accepts these dashboard-facing NACE levels:
-
-- `nace_section`
-- `nace_division`
-- `nace_group`
-- `nace_class`
-
-`nace_code` remains accepted as a technical compatibility value in the route signature, but the service builds dashboard NACE views for section, division, group and class.
-
-`nace_section` is derived from official division ranges `A` through `U`.
-
-## Multi-Mapping Semantics
-
-One ESCO occupation may map to more than one NACE code. The current implementation keeps all mappings.
-
-This means NACE mode is relation-oriented:
-- it is useful for discovering skill-sector relationships,
-- it is not strict one-to-one job accounting,
-- one job-derived skill can contribute to multiple NACE sectors when its occupation has multiple crosswalk mappings.
-
-## Sectoral Payload
-
-When `include_sectoral=true`, `/projector/analyze-skills` returns sectoral data in:
-
-- `insights.sectoral`
-- `insights.sectoral_mode`
-- `insights.sectoral_views`
-- `insights.sector_view_names`
-
-`insights.sectoral` is kept for backward compatibility. In the current service:
-- if `sector_system=nace`, it contains the selected NACE level,
-- otherwise it contains the ISCO payload.
-
-`insights.sectoral_views` contains both systems:
+When `include_sectoral=true`, `/projector/analyze-skills` returns:
 
 ```json
 {
-  "isco": {
-    "sector_level": "isco_group",
-    "items": []
-  },
-  "nace": {
-    "selected_level": "nace_section",
-    "levels": {
-      "nace_section": { "sector_level": "nace_section", "items": [] },
-      "nace_division": { "sector_level": "nace_division", "items": [] },
-      "nace_group": { "sector_level": "nace_group", "items": [] },
-      "nace_class": { "sector_level": "nace_class", "items": [] }
+  "sectoral_mode": "nace",
+  "sectoral": [],
+  "sectoral_views": {
+    "nace": {
+      "sector_level": "tracker_sector",
+      "items": []
     }
   }
 }
 ```
 
-## Analytical Layers
+Each item contains:
+- `sector`
+- `sector_label`
+- `observed_skills`
+- `observed_groups`
+- `sector_metrics`
+- `skill_transversal_insights`
 
-Each sector item can include:
+## Interpretation
 
-- observed skills: skills found directly in Tracker jobs
-- canonical skills: ESCO occupation-skill relations aggregated by sector
-- observed groups: observed skills aggregated into ESCO skill groups
-- canonical groups: canonical skills aggregated into ESCO skill groups
-- matrix groups: official ESCO matrix profiles aggregated by sector
-- sector metrics: coverage and top-skill dominance
-- skill transversality: sector breadth and concentration for top skills
-- ISCO interpretation: observed/canonical gap and overlap, only for ISCO views
+Sector totals are relationship counts, not unique job counts.
 
-## Naming Semantics
+One job with 3 sectors and 10 skills contributes 30 sector-skill events.
 
-For ISCO:
-- Observed
-- Canonical
-- Official Matrix
-
-For NACE:
-- Observed
-- Derived Canonical
-- Aggregated Official Matrix
-
-The NACE canonical and matrix views are ESCO-derived projections aggregated through the crosswalk; they are not native NACE ontologies.
-
-## NACE Derivation Process
-
-The derived NACE views are built by joining occupation-level evidence to NACE mappings, then aggregating into the selected NACE level.
-
-| Step | Derived Canonical (NACE) | Aggregated Official Matrix (NACE) |
-| --- | --- | --- |
-| 1. Job input | Fetch job postings from Tracker | Fetch job postings from Tracker |
-| 2. Occupation extraction | Extract ESCO occupation ids from jobs | Extract ESCO occupation ids from jobs |
-| 3. Sector mapping | Map each occupation to one or more NACE codes using the ESCO-NACE crosswalk | Map each occupation to one or more NACE codes using the ESCO-NACE crosswalk |
-| 4. Skill source | Retrieve canonical skills linked to each occupation from ESCO relations CSV | Retrieve official ESCO skill-group profile from ESCO Matrix XLSX |
-| 5. Skill transformation | Keep skill-level granularity as individual ESCO skills | Keep skill-group level using ESCO matrix definitions |
-| 6. Aggregation logic | For each job occurrence of an occupation, assign all its canonical skills to each mapped NACE sector | For each job occurrence of an occupation, assign its ESCO matrix profile to each mapped NACE sector |
-| 7. Counting mechanism | Each canonical skill contributes `+1` per job occurrence per sector | Each skill group contributes its matrix share as a float per job occurrence per sector |
-| 8. Multi-mapping handling | If an occupation maps to multiple NACE sectors, all sectors receive the same skill contributions | If an occupation maps to multiple NACE sectors, all sectors receive the same matrix profile contributions |
-| 9. Sector aggregation | Aggregate skill counts per NACE sector | Aggregate skill-group shares per NACE sector |
-| 10. Output structure | `sector -> skills -> counts / frequency` | `sector -> skill groups -> aggregated shares / frequency` |
-
-## Derived Canonical NACE Pipeline
-
-```text
-job
- -> occupation (ESCO)
-    -> canonical skills from ESCO relations
-    -> NACE sectors from ESCO-NACE crosswalk
- -> assign each canonical skill to each mapped NACE sector
- -> aggregate counts by selected NACE level
-```
-
-Expanded logic:
-
-```text
-job
- -> occupation_id
-    -> ESCO skills
-    -> NACE mappings
- -> join skills to mapped NACE sectors
- -> each skill contributes +1 per job occurrence per sector
- -> counts per NACE sector
-```
-
-## Aggregated Official Matrix NACE Pipeline
-
-```text
-job
- -> occupation (ESCO)
-    -> ESCO matrix profile (skill groups and shares)
-    -> NACE sectors from ESCO-NACE crosswalk
- -> assign each matrix skill-group share to each mapped NACE sector
- -> aggregate weighted shares by selected NACE level
-```
-
-Expanded logic:
-
-```text
-job
- -> occupation_id
-    -> ESCO matrix profile
-    -> NACE mappings
- -> join matrix groups to mapped NACE sectors
- -> each group contributes its share per job occurrence per sector
- -> weighted aggregation by NACE sector
-```
-
-## Key Difference Between Derived NACE Views
-
-```text
-Derived Canonical:
-+1 per canonical skill
-
-Aggregated Official Matrix:
-+share per skill group
-```
-
-Derived Canonical:
-- represents ESCO-defined occupation-skill relationships,
-- is re-aggregated by NACE sectors,
-- keeps skill-level granularity,
-- treats each skill as equally relevant in the current implementation.
-
-Aggregated Official Matrix:
-- represents official ESCO skill-group profiles,
-- is aggregated by NACE sectors,
-- uses skill-group granularity,
-- preserves relative importance values from the ESCO matrix.
+This is intentional: the dashboard answers which skills are associated with which Tracker sectors in the analyzed batch.

--- a/docs/statistic.md
+++ b/docs/statistic.md
@@ -1,0 +1,186 @@
+# Statistics
+
+Concise formulas for current API-only metrics.
+
+## Jobs
+
+`jobs_analyzed`
+
+```text
+count(jobs)
+```
+
+Number of Tracker jobs processed after filters.
+
+## Skills
+
+`frequency`
+
+```text
+count(skill mentions in all jobs)
+```
+
+One job can contribute multiple skills.
+
+`sector_spread`
+
+```text
+count(distinct sectors where skill appears)
+```
+
+Uses Tracker `job["sectors"]`.
+
+`primary_sector`
+
+```text
+sector with max count for that skill
+```
+
+## Sectors
+
+Sector counts are relationship counts.
+
+```text
+for each job:
+  for each sector in job["sectors"]:
+    sector_count[sector] += 1
+```
+
+If a job has multiple sectors, each sector gets one count.
+
+## Sector-Skill Matrix
+
+Core matrix:
+
+```text
+for each job:
+  for each sector in job["sectors"]:
+    for each skill in job["skills"]:
+      sector_skill_count[sector][skill] += 1
+```
+
+If a job has no sector, sector is `Sector not specified`.
+
+## Observed Skills In Sector
+
+`count`
+
+```text
+sector_skill_count[sector][skill]
+```
+
+`total_skill_mentions`
+
+```text
+sum(sector_skill_count[sector].values())
+```
+
+`unique_skills`
+
+```text
+count(distinct skills in sector)
+```
+
+`frequency`
+
+```text
+skill count in sector / total_skill_mentions in sector
+```
+
+## Sector Metrics
+
+`coverage_unique_skills`
+
+```text
+unique_skills in sector
+```
+
+`dominance_top10_share`
+
+```text
+sum(top 10 skill counts in sector) / total_skill_mentions in sector
+```
+
+High value means demand is concentrated in few skills.
+
+## Skill Importance
+
+`importance_in_sector`
+
+```text
+skill count in selected sector / total_skill_mentions in selected sector
+```
+
+It answers: how important is this skill inside the selected sector?
+
+## Skill Transversality
+
+`sector_breadth`
+
+```text
+count(sectors where skill appears)
+```
+
+It answers: how many sectors use this skill?
+
+`dominant_sector`
+
+```text
+sector with highest count for the skill
+```
+
+`dominant_share`
+
+```text
+skill count in dominant sector / total skill count across all sectors
+```
+
+It is linked to `dominant_sector_label`.
+
+## Regional
+
+`total_jobs`
+
+```text
+count(jobs in area)
+```
+
+`market_share`
+
+```text
+jobs in area / all jobs * 100
+```
+
+`specialization`
+
+```text
+(skill count in area / jobs in area) / (skill count globally / all jobs)
+```
+
+Above `1` means the skill is more concentrated in that area than in the full analyzed market.
+
+## Trends
+
+The selected date range is split in two halves.
+
+`growth`
+
+```text
+(count in second half - count in first half) / count in first half * 100
+```
+
+If first-half count is `0` and second-half count is positive, growth is `new_entry`.
+
+`trend_type`
+
+```text
+growth > 0 -> emerging
+growth < 0 -> declining
+growth = 0 -> stable
+```
+
+`volume_growth_percentage`
+
+```text
+(jobs in second half - jobs in first half) / jobs in first half * 100
+```


### PR DESCRIPTION
## Summary

- Use Tracker API `job["sectors"]` instead of local ISCO/NACE files for sector intelligence.
- Build sector-skill mappings from observed job data: `job["sectors"] x job["skills"]`.
- Remove dashboard ISCO comparison, NACE hierarchy selector, canonical/matrix views.
- Add localized dashboard API hints and metric tooltips for frontend integration.
- Update docs and add `docs/statistic.md` with concise metric formulas.

## Verification

- `python -m py_compile ...`
- Streamlit dashboard smoke test returned HTTP 200.

Closing #37.
Closing #38.